### PR TITLE
use the naturalearth data in the naturalearth example

### DIFF
--- a/docs/examples/naturalearth/style.json
+++ b/docs/examples/naturalearth/style.json
@@ -1,7 +1,5 @@
 {
   "version" : 8,
-  "center" : [ 0, 0 ],
-  "zoom" : 4,
   "sources" : {
     "baremaps" : {
       "type" : "vector",
@@ -9,12 +7,27 @@
     }
   },
   "layers" : [ {
-    "id" : "building",
+    "id" : "ne_50m_admin_0_countries",
     "type" : "fill",
     "source" : "baremaps",
-    "source-layer" : "building",
+    "source-layer" : "ne_50m_admin_0_countries",
+    "layout" : {
+      "visibility" : "visible"
+    },
     "paint" : {
-      "fill-color" : "rgba(255, 0, 0, 1)"
+      "fill-color" : "rgba(125, 105, 105, 1)",
+      "fill-outline-color" : "rgba(0, 0, 0, 1)"
     }
-  } ] 
+  }, {
+    "id" : "ne_10m_admin_0_countries",
+    "type" : "fill",
+    "source" : "baremaps",
+    "source-layer" : "ne_10m_admin_0_countries",
+    "paint" : {
+      "fill-color" : "rgba(125, 105, 105, 1)",
+      "fill-outline-color" : "rgba(0, 0, 0, 1)"
+    }
+  } ],
+  "center" : [ 0, 0 ],
+  "zoom" : 4
 }


### PR DESCRIPTION
I noticed that the naturalearth example style was the same as the one for OSM. So I changed it to use a couple of naturalearth data. It produces a style like this:
![image](https://user-images.githubusercontent.com/2493436/136653575-01f18962-b2d6-4ef1-912f-9cec550d6433.png)
