### PR TITLE
Use .asf.yaml to manage GitHub settings

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+github:
+  description: Create custom vector tiles from OpenStreetMap and other data sources with Postgis and Java.
+  homepage: www.baremaps.com
+  labels:
+    - java 
+    - vector-tiles 
+    - openstreetmap 
+    - postgresql 
+    - postgis 
+    - mapbox 
+    - spatial-data 
+    - web-mapping
+  enabled_merge_buttons:
+    squash: true
+    merge: false
+    rebase: false
+  protected_branches:
+    main:
+      required_status_checks:
+        strict: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        required_approving_review_count: 1
+
+notifications:
+  commits:      commits@baremaps.apache.org
+  issues:       commits@baremaps.apache.org
+  pullrequests: commits@baremaps.apache.org


### PR DESCRIPTION
`.asf.yaml` is a configuration file that a project may use to control various features such as notification schemes, website staging, GitHub settings, and Pelican builds.
how to use: this:https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features

- Set the code merge method to squash
- Set GitHub notifications to: commits@apache.o.g
- Set  protected_branches