### PR TITLE
Order IP to location by size of IP range

### DIFF
--- a/baremaps-core/src/main/java/org/apache/baremaps/iploc/database/InetnumLocationDaoSqliteImpl.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/iploc/database/InetnumLocationDaoSqliteImpl.java
@@ -43,7 +43,7 @@ public final class InetnumLocationDaoSqliteImpl implements InetnumLocationDao {
 
   private static final String SELECT_ALL_BY_IP_SQL = "SELECT id, address, "
       + "ip_start, ip_end, latitude, longitude, network, "
-      + "country FROM inetnum_locations WHERE ip_start <= ? AND ip_end >= ? ORDER BY ip_start DESC;";
+      + "country FROM inetnum_locations WHERE ip_start <= ? AND ip_end >= ? ORDER BY ip_start DESC, ip_end ASC;";
 
   private static final Logger logger = LoggerFactory.getLogger(InetnumLocationDaoSqliteImpl.class);
 

--- a/baremaps-core/src/main/java/org/apache/baremaps/iploc/database/InetnumLocationDaoSqliteImpl.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/iploc/database/InetnumLocationDaoSqliteImpl.java
@@ -38,13 +38,12 @@ public final class InetnumLocationDaoSqliteImpl implements InetnumLocationDao {
   private static final String INSERT_SQL =
       "INSERT INTO inetnum_locations(address, ip_start, ip_end, latitude, longitude, network, country) VALUES(?,?,?,?,?,?,?)";
 
-  private static final String SELECT_ALL_SQL =
-      "SELECT " + "id, \n" + "address, \n" + "ip_start, \n" + "ip_end, \n" + "latitude, \n"
-          + "longitude, \n" + "network, \n" + "country \n" + " FROM inetnum_locations;";
+  private static final String SELECT_ALL_SQL = "SELECT id, address, ip_start, ip_end, latitude, "
+      + "longitude, network, country FROM inetnum_locations;";
 
-  private static final String SELECT_ALL_BY_IP_SQL = "SELECT " + "id, \n" + "address, \n"
-      + "ip_start, \n" + "ip_end, \n" + "latitude, \n" + "longitude, \n" + "network, \n"
-      + "country FROM inetnum_locations WHERE ip_start <= ? AND ip_end >= ?;";
+  private static final String SELECT_ALL_BY_IP_SQL = "SELECT id, address, "
+      + "ip_start, ip_end, latitude, longitude, network, "
+      + "country FROM inetnum_locations WHERE ip_start <= ? AND ip_end >= ? ORDER BY ip_start DESC;";
 
   private static final Logger logger = LoggerFactory.getLogger(InetnumLocationDaoSqliteImpl.class);
 

--- a/baremaps-core/src/main/java/org/apache/baremaps/iploc/database/InetnumLocationDaoSqliteImpl.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/iploc/database/InetnumLocationDaoSqliteImpl.java
@@ -36,14 +36,19 @@ import org.sqlite.SQLiteDataSource;
 public final class InetnumLocationDaoSqliteImpl implements InetnumLocationDao {
 
   private static final String INSERT_SQL =
-      "INSERT INTO inetnum_locations(address, ip_start, ip_end, latitude, longitude, network, country) VALUES(?,?,?,?,?,?,?)";
+      """
+          INSERT INTO inetnum_locations(address, ip_start, ip_end, latitude, longitude, network, country)
+          VALUES(?,?,?,?,?,?,?)""";
 
-  private static final String SELECT_ALL_SQL = "SELECT id, address, ip_start, ip_end, latitude, "
-      + "longitude, network, country FROM inetnum_locations;";
+  private static final String SELECT_ALL_SQL = """
+      SELECT id, address, ip_start, ip_end, latitude, longitude, network, country
+      FROM inetnum_locations;""";
 
-  private static final String SELECT_ALL_BY_IP_SQL = "SELECT id, address, "
-      + "ip_start, ip_end, latitude, longitude, network, "
-      + "country FROM inetnum_locations WHERE ip_start <= ? AND ip_end >= ? ORDER BY ip_start DESC, ip_end ASC;";
+  private static final String SELECT_ALL_BY_IP_SQL = """
+      SELECT id, address, ip_start, ip_end, latitude, longitude, network, country
+      FROM inetnum_locations
+      WHERE ip_start <= ? AND ip_end >= ?
+      ORDER BY ip_start DESC, ip_end ASC;""";
 
   private static final Logger logger = LoggerFactory.getLogger(InetnumLocationDaoSqliteImpl.class);
 


### PR DESCRIPTION
As described in #530, we should order the resulting IP ranges by size of range. In the SQLite database we store start and end IP addresses. To sort by size of range, we should substract IP end by IP start. This doesn't seem to be possible in a SQL query with SQLITE using bitwise operators. We could possibly store the range in separate field for sorting purposes.
For now I sort by IP start DESC, which should give us the most precise range in most cases. When two IP start values are equal, I will sort them by IP end ASC to get the shortest range.