### PR TITLE
Create a new index that includes both ip_start and ip_end

### DIFF
--- a/baremaps-core/src/main/resources/iploc_init.sql
+++ b/baremaps-core/src/main/resources/iploc_init.sql
@@ -9,5 +9,4 @@ CREATE TABLE IF NOT EXISTS inetnum_locations (
     network text,
     country text
 );
-CREATE INDEX ip_start_index ON inetnum_locations (ip_start);
-CREATE INDEX ip_end_index ON inetnum_locations (ip_end);
+CREATE INDEX inetnum_locations_ips ON inetnum_locations (ip_start,ip_end);


### PR DESCRIPTION
Following up on #544 I have create a new index to replace the previous ones. It will index on ip_start and then on ip_end. This will greatly reduce the query time to find IPs in-between ip_start and ip_end.

In my tests, I have found that I go from 6.5 seconds to query an IP by range to about 0.5 seconds.

Using `EXPLAIN QUERY PLAN`, we can see that we use the new index `SEARCH inetnum_locations USING INDEX inetnum_locations_ips (ip_start>?)`. 

