### PR TITLE
Update the IntelliJ configurations

### DIFF
--- a/.run/geocoder-create.run.xml
+++ b/.run/geocoder-create.run.xml
@@ -2,7 +2,8 @@
   <configuration default="false" name="geocoder-create" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
-    <option name="PROGRAM_PARAMETERS" value="workflow execute --file examples/geocoding/workflow.js" />
+    <option name="PROGRAM_PARAMETERS" value="workflow execute --file workflow.js" />
+    <option name="WORKING_DIRECTORY" value="examples/geocoding" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/geocoder-create.run.xml
+++ b/.run/geocoder-create.run.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
     <option name="PROGRAM_PARAMETERS" value="workflow execute --file workflow.js" />
-    <option name="WORKING_DIRECTORY" value="examples/geocoding" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/geocoding" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/geocoder-serve.run.xml
+++ b/.run/geocoder-serve.run.xml
@@ -5,7 +5,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
     <option name="PROGRAM_PARAMETERS" value="geocoder serve --index geocoder-index --port 9000" />
-    <option name="WORKING_DIRECTORY" value="examples/geocoding" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/geocoding" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/geocoder-serve.run.xml
+++ b/.run/geocoder-serve.run.xml
@@ -5,6 +5,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
     <option name="PROGRAM_PARAMETERS" value="geocoder serve --index geocoder-index --port 9000" />
+    <option name="WORKING_DIRECTORY" value="examples/geocoding" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/iploc-create.run.xml
+++ b/.run/iploc-create.run.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
     <option name="PROGRAM_PARAMETERS" value="workflow execute --file workflow.js" />
-    <option name="WORKING_DIRECTORY" value="examples/ip-to-location" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/ip-to-location" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/iploc-serve.run.xml
+++ b/.run/iploc-serve.run.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
     <option name="PROGRAM_PARAMETERS" value="iploc serve --database iploc.db --port 9000" />
-    <option name="WORKING_DIRECTORY" value="examples/ip-to-location" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/ip-to-location" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/iploc-serve.run.xml
+++ b/.run/iploc-serve.run.xml
@@ -3,6 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
     <option name="PROGRAM_PARAMETERS" value="iploc serve --database iploc.db --port 9000" />
+    <option name="WORKING_DIRECTORY" value="examples/ip-to-location" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/naturalearth-create.run.xml
+++ b/.run/naturalearth-create.run.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
     <option name="PROGRAM_PARAMETERS" value="workflow execute --file workflow.json" />
-    <option name="WORKING_DIRECTORY" value="examples/naturalearth" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/naturalearth" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/naturalearth-create.run.xml
+++ b/.run/naturalearth-create.run.xml
@@ -1,9 +1,9 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="iploc-create" type="Application" factoryName="Application">
+  <configuration default="false" name="naturalearth-create" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
-    <option name="PROGRAM_PARAMETERS" value="workflow execute --file workflow.js" />
-    <option name="WORKING_DIRECTORY" value="examples/ip-to-location" />
+    <option name="PROGRAM_PARAMETERS" value="workflow execute --file workflow.json" />
+    <option name="WORKING_DIRECTORY" value="examples/naturalearth" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/naturalearth-dev.run.xml
+++ b/.run/naturalearth-dev.run.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
     <option name="PROGRAM_PARAMETERS" value="map dev --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset tileset.json --style style.json" />
-    <option name="WORKING_DIRECTORY" value="examples/naturalearth" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/naturalearth" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/naturalearth-dev.run.xml
+++ b/.run/naturalearth-dev.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="naturalearth-dev" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
+    <module name="baremaps-cli" />
+    <option name="PROGRAM_PARAMETERS" value="map dev --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset tileset.json --style style.json" />
+    <option name="WORKING_DIRECTORY" value="examples/naturalearth" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/openstreetmap-dev.run.xml
+++ b/.run/openstreetmap-dev.run.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
     <option name="PROGRAM_PARAMETERS" value="map dev --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset tileset.json --style style.json" />
-    <option name="WORKING_DIRECTORY" value="examples/openstreetmap" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/openstreetmap" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.apache.baremaps.server.ogcapi.*" />

--- a/.run/openstreetmap-dev.run.xml
+++ b/.run/openstreetmap-dev.run.xml
@@ -1,9 +1,9 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="map-export" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.Baremaps" />
-    <module name="baremaps-benchmark" />
-    <option name="PROGRAM_PARAMETERS" value="map export --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset tileset.json --repository tiles/" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/docs/examples/openstreetmap" />
+  <configuration default="false" name="openstreetmap-dev" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
+    <module name="baremaps-cli" />
+    <option name="PROGRAM_PARAMETERS" value="map dev --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset tileset.json --style style.json" />
+    <option name="WORKING_DIRECTORY" value="examples/openstreetmap" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.apache.baremaps.server.ogcapi.*" />

--- a/.run/openstreetmap-export.run.xml
+++ b/.run/openstreetmap-export.run.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
     <option name="PROGRAM_PARAMETERS" value="map export --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset tileset.json --repository tiles/" />
-    <option name="WORKING_DIRECTORY" value="examples/openstreetmap" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/openstreetmap" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.apache.baremaps.server.ogcapi.*" />

--- a/.run/openstreetmap-export.run.xml
+++ b/.run/openstreetmap-export.run.xml
@@ -1,9 +1,9 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="map-serve" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.Baremaps" />
-    <module name="baremaps-benchmark" />
-    <option name="PROGRAM_PARAMETERS" value="map serve --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset tileset.json --style style.json" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/docs/examples/openstreetmap" />
+  <configuration default="false" name="openstreetmap-export" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
+    <module name="baremaps-cli" />
+    <option name="PROGRAM_PARAMETERS" value="map export --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset tileset.json --repository tiles/" />
+    <option name="WORKING_DIRECTORY" value="examples/openstreetmap" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.apache.baremaps.server.ogcapi.*" />

--- a/.run/openstreetmap-serve.run.xml
+++ b/.run/openstreetmap-serve.run.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
     <option name="PROGRAM_PARAMETERS" value="map serve --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset tileset.json --style style.json" />
-    <option name="WORKING_DIRECTORY" value="examples/openstreetmap" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/openstreetmap" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.apache.baremaps.server.ogcapi.*" />

--- a/.run/openstreetmap-serve.run.xml
+++ b/.run/openstreetmap-serve.run.xml
@@ -1,9 +1,9 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="workflow-init" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.Baremaps" />
-    <module name="baremaps-benchmark" />
-    <option name="PROGRAM_PARAMETERS" value="workflow init --file sample-workflow.json" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/docs/examples/openstreetmap" />
+  <configuration default="false" name="openstreetmap-serve" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
+    <module name="baremaps-cli" />
+    <option name="PROGRAM_PARAMETERS" value="map serve --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset examples/openstreetmap/cesium-tileset.json --style style.json" />
+    <option name="WORKING_DIRECTORY" value="examples/openstreetmap" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.apache.baremaps.server.ogcapi.*" />

--- a/.run/openstreetmap-serve.run.xml
+++ b/.run/openstreetmap-serve.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="openstreetmap-serve" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
-    <option name="PROGRAM_PARAMETERS" value="map serve --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset examples/openstreetmap/cesium-tileset.json --style style.json" />
+    <option name="PROGRAM_PARAMETERS" value="map serve --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset tileset.json --style style.json" />
     <option name="WORKING_DIRECTORY" value="examples/openstreetmap" />
     <extension name="coverage">
       <pattern>

--- a/.run/workflow-execute.run.xml
+++ b/.run/workflow-execute.run.xml
@@ -3,7 +3,6 @@
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
     <option name="PROGRAM_PARAMETERS" value="workflow execute --file workflow.js" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/map" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.apache.baremaps.server.ogcapi.*" />

--- a/.run/workflow-init.run.xml
+++ b/.run/workflow-init.run.xml
@@ -1,9 +1,8 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="map-dev" type="Application" factoryName="Application">
+  <configuration default="false" name="workflow-init" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
-    <option name="PROGRAM_PARAMETERS" value="map dev --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset tileset.js --style style.js" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/map" />
+    <option name="PROGRAM_PARAMETERS" value="workflow init --file sample-workflow.json" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.apache.baremaps.server.ogcapi.*" />


### PR DESCRIPTION
Most of the configurations are broken since modules have been renamed/moved. We should update the configurations to use the baremaps-cli module. We should also create new configurations in relation to the examples.