### PR TITLE
Put the extrusion example back in place

### DIFF
--- a/.run/extrusion-create.run.xml
+++ b/.run/extrusion-create.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="extrusion-create" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
+    <module name="baremaps-cli" />
+    <option name="PROGRAM_PARAMETERS" value="workflow execute --file workflow.json" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/extrusion" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/extrusion-dev.run.xml
+++ b/.run/extrusion-dev.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="extrusion-dev" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
+    <module name="baremaps-cli" />
+    <option name="PROGRAM_PARAMETERS" value="map dev --database jdbc:postgresql://localhost:5432/baremaps?user=baremaps&amp;password=baremaps --tileset tileset.json --style style.json" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/extrusion" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/examples/extrusion/README.md
+++ b/examples/extrusion/README.md
@@ -1,0 +1,5 @@
+# OpenStreetMap example
+
+This folder contains the required files to create and serve vector tiles from contour lines data. 
+
+Refer to the [official documentation](https://baremaps.apache.org/examples/import-contour-into-postgis/) for more information.

--- a/examples/extrusion/indexes.sql
+++ b/examples/extrusion/indexes.sql
@@ -1,0 +1,5 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_ways_gin ON osm_ways USING gin (nodes);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_relations_gin ON osm_relations USING gin (member_refs);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_nodes_gix ON osm_nodes USING GIST (geom);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_ways_gix ON osm_ways USING GIST (geom);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_relations_gix ON osm_relations USING GIST (geom);

--- a/examples/extrusion/style.json
+++ b/examples/extrusion/style.json
@@ -1,0 +1,31 @@
+{
+  "version": 8,
+  "center": [
+    0.1278,
+    51.5074
+  ],
+  "zoom": 14,
+  "sources": {
+    "baremaps": {
+      "type": "vector",
+      "url": "http://localhost:9000/tiles.json"
+    }
+  },
+  "layers": [
+    {
+      "id": "building",
+      "type": "fill-extrusion",
+      "source": "baremaps",
+      "source-layer": "building",
+      "paint": {
+        "fill-extrusion-color": "rgb(152, 174, 221)",
+        "fill-extrusion-height": [
+          "get",
+          "building:height"
+        ],
+        "fill-extrusion-base": 0,
+        "fill-extrusion-opacity": 0.9
+      }
+    }
+  ]
+}

--- a/examples/extrusion/tileset.json
+++ b/examples/extrusion/tileset.json
@@ -1,0 +1,31 @@
+{
+  "tilejson": "2.2.0",
+  "center": [
+    0.1278,
+    51.5074,
+    14.0
+  ],
+  "bounds": [
+    -0.511482,
+    51.28554,
+    0.335437,
+    51.69344
+  ],
+  "minzoom": 12.0,
+  "maxzoom": 14.0,
+  "tiles": [
+    "http://localhost:9000/tiles/{z}/{x}/{y}.mvt"
+  ],
+  "vector_layers": [
+    {
+      "id": "building",
+      "queries": [
+        {
+          "minzoom": 12,
+          "maxzoom": 20,
+          "sql": "SELECT id, tags || jsonb_build_object('building:height', (CASE WHEN tags ->> 'building:levels' ~ '^[0-9\\\\.]+$' THEN tags ->> 'building:levels' ELSE '1' END)::real * 3), geom FROM osm_ways WHERE tags ? 'building'"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/extrusion/workflow.json
+++ b/examples/extrusion/workflow.json
@@ -1,0 +1,42 @@
+{
+  "steps": [
+    {
+      "id": "download",
+      "needs": [],
+      "tasks": [
+        {
+          "type": "DownloadUrl",
+          "url": "https://download.geofabrik.de/europe/great-britain/england/greater-london-latest.osm.pbf",
+          "path": "greater-london-latest.osm.pbf"
+        }
+      ]
+    },
+    {
+      "id": "import",
+      "needs": [
+        "download"
+      ],
+      "tasks": [
+        {
+          "type": "ImportOpenStreetMap",
+          "file": "greater-london-latest.osm.pbf",
+          "database": "jdbc:postgresql://localhost:5432/baremaps?&user=baremaps&password=baremaps",
+          "databaseSrid": 3857
+        }
+      ]
+    },
+    {
+      "id": "index",
+      "needs": [
+        "import"
+      ],
+      "tasks": [
+        {
+          "type": "ExecuteSql",
+          "file": "indexes.sql",
+          "database": "jdbc:postgresql://localhost:5432/baremaps?&user=baremaps&password=baremaps"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The extrusion example had been lost. I have put it back and updated the documentation on the website and the run configurations for IntelliJ. You can see the documentation here [https://baremaps.apache.org/examples/extrusion/](https://baremaps.apache.org/examples/extrusion/).