### PR TITLE
Fix missing license headers

### DIFF
--- a/.run/workflow-execute.run.xml
+++ b/.run/workflow-execute.run.xml
@@ -2,7 +2,8 @@
   <configuration default="false" name="workflow-execute" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.baremaps.cli.Baremaps" />
     <module name="baremaps-cli" />
-    <option name="PROGRAM_PARAMETERS" value="workflow execute --file workflow.js" />
+    <option name="PROGRAM_PARAMETERS" value="workflow execute --file workflow.json" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/simplification" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.apache.baremaps.server.ogcapi.*" />

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,14 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,14 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 # Contributing to Baremaps
 
 This document describes the way you can contribute to the Baremaps project.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 <div align="center">
 <br/>
 <img src="logo.svg" width="100px">

--- a/baremaps-core/src/main/resources/iploc_init.sql
+++ b/baremaps-core/src/main/resources/iploc_init.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP TABLE IF EXISTS inetnum_locations;
 CREATE TABLE IF NOT EXISTS inetnum_locations (
     id integer PRIMARY KEY,

--- a/baremaps-core/src/test/java/org/apache/baremaps/workflow/tasks/ExecuteSqlTest.java
+++ b/baremaps-core/src/test/java/org/apache/baremaps/workflow/tasks/ExecuteSqlTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.baremaps.workflow.tasks;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ExecuteSqlTest {
+
+  private static final String INPUT = """
+      SELECT 1;
+      -- test
+      SELECT 2;
+      /* test */
+      SELECT 3;
+      /*
+      test
+      */
+      """;
+
+  private static final String OUTPUT = "SELECT 1;SELECT 2;SELECT 3;";
+
+  @Test
+  void removeComments() {
+    var queriesWithoutComments = ExecuteSql.removeComments(INPUT).strip();
+    assertEquals(OUTPUT.trim(), queriesWithoutComments.replace("\n", "").strip());
+  }
+}

--- a/baremaps-core/src/test/resources/queries/osm_create_extensions.sql
+++ b/baremaps-core/src/test/resources/queries/osm_create_extensions.sql
@@ -1,2 +1,11 @@
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE EXTENSION IF NOT EXISTS hstore;
 CREATE EXTENSION IF NOT EXISTS postgis;

--- a/baremaps-core/src/test/resources/queries/osm_create_gin_indexes.sql
+++ b/baremaps-core/src/test/resources/queries/osm_create_gin_indexes.sql
@@ -1,2 +1,11 @@
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_ways_gin ON osm_ways USING gin (nodes);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_relations_gin ON osm_relations USING gin (member_refs);

--- a/baremaps-core/src/test/resources/queries/osm_create_gist_indexes.sql
+++ b/baremaps-core/src/test/resources/queries/osm_create_gist_indexes.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_nodes_gix ON osm_nodes USING GIST (geom);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_ways_gix ON osm_ways USING GIST (geom);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_relations_gix ON osm_relations USING GIST (geom);

--- a/baremaps-core/src/test/resources/queries/osm_create_spgist_indexes.sql
+++ b/baremaps-core/src/test/resources/queries/osm_create_spgist_indexes.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_nodes_gix ON osm_nodes USING SPGIST (geom);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_ways_gix ON osm_ways USING SPGIST (geom);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_relations_gix ON osm_relations USING SPGIST (geom);

--- a/baremaps-core/src/test/resources/queries/osm_create_tables.sql
+++ b/baremaps-core/src/test/resources/queries/osm_create_tables.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE TABLE IF NOT EXISTS osm_headers
 (
     replication_sequence_number bigint PRIMARY KEY,

--- a/baremaps-core/src/test/resources/queries/osm_drop_tables.sql
+++ b/baremaps-core/src/test/resources/queries/osm_drop_tables.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP TABLE IF EXISTS osm_headers;
 DROP TABLE IF EXISTS osm_nodes;
 DROP TABLE IF EXISTS osm_ways;

--- a/baremaps-core/src/test/resources/queries/osm_truncate_table.sql
+++ b/baremaps-core/src/test/resources/queries/osm_truncate_table.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 TRUNCATE TABLE osm_headers;
 TRUNCATE TABLE osm_nodes;
 TRUNCATE TABLE osm_ways;

--- a/baremaps-core/src/test/resources/queries/queries.sql
+++ b/baremaps-core/src/test/resources/queries/queries.sql
@@ -1,3 +1,13 @@
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
+
 SELECT 1;
 SELECT 2;
 SELECT 3;

--- a/baremaps-core/src/test/resources/queries/schema.sql
+++ b/baremaps-core/src/test/resources/queries/schema.sql
@@ -1,5 +1,15 @@
 -- mbtiles schema
 
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
+
 BEGIN;
 
 CREATE TABLE indexdata (name text, value text);

--- a/baremaps-core/src/test/resources/style.yaml
+++ b/baremaps-core/src/test/resources/style.yaml
@@ -1,1 +1,11 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#    in compliance with the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software distributed under the License
+#    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#    or implied. See the License for the specific language governing permissions and limitations under
+#    the License.
+
 name: "style"

--- a/baremaps-server/src/main/resources/assets/server.html
+++ b/baremaps-server/src/main/resources/assets/server.html
@@ -1,3 +1,15 @@
+<!DOCTYPE html>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 <html>
 <head>
   <script src='https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.js'></script>

--- a/baremaps-server/src/main/resources/assets/viewer.html
+++ b/baremaps-server/src/main/resources/assets/viewer.html
@@ -1,3 +1,15 @@
+<!DOCTYPE html>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 <html>
 <head>
   <script src='https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.js'></script>

--- a/baremaps-server/src/main/resources/geocoder/index.html
+++ b/baremaps-server/src/main/resources/geocoder/index.html
@@ -1,4 +1,15 @@
 <!DOCTYPE html>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 <html>
 <head>
     <meta charset="utf-8"/>

--- a/baremaps-server/src/main/resources/iploc/index.html
+++ b/baremaps-server/src/main/resources/iploc/index.html
@@ -1,4 +1,15 @@
 <!DOCTYPE html>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 <html>
 <head>
     <meta charset="utf-8"/>

--- a/basemap/README.md
+++ b/basemap/README.md
@@ -1,3 +1,14 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 # OpenStreetMap Vecto
 
 🚧 🚧 Work in progress 🚧 🚧

--- a/basemap/config.js
+++ b/basemap/config.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "host": "http://localhost:9000",
     "database": "jdbc:postgresql://localhost:5432/baremaps?&user=baremaps&password=baremaps",

--- a/basemap/layers/aerialway/style.js
+++ b/basemap/layers/aerialway/style.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'aerialway_line',
     type: 'line',

--- a/basemap/layers/aerialway/tileset.js
+++ b/basemap/layers/aerialway/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'aerialway',
     queries: [

--- a/basemap/layers/aeroway/line.js
+++ b/basemap/layers/aeroway/line.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/aeroway/polygon.js
+++ b/basemap/layers/aeroway/polygon.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/aeroway/tileset.js
+++ b/basemap/layers/aeroway/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'aeroway',
     queries: [

--- a/basemap/layers/amenity/background.js
+++ b/basemap/layers/amenity/background.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/amenity/fountain.js
+++ b/basemap/layers/amenity/fountain.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/amenity/overlay.js
+++ b/basemap/layers/amenity/overlay.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/amenity/tileset.js
+++ b/basemap/layers/amenity/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'amenity',
     queries: [

--- a/basemap/layers/attraction/style.js
+++ b/basemap/layers/attraction/style.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default [
     {
         id: 'water_slide_casing',

--- a/basemap/layers/attraction/tileset.js
+++ b/basemap/layers/attraction/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'attraction',
     queries: [

--- a/basemap/layers/background/style.js
+++ b/basemap/layers/background/style.js
@@ -1,3 +1,14 @@
+/**
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+**/
 export default {
     id: 'background',
     type: 'background',

--- a/basemap/layers/barrier/style.js
+++ b/basemap/layers/barrier/style.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default [
     {
         id: 'barrier_guard_rail',

--- a/basemap/layers/barrier/tileset.js
+++ b/basemap/layers/barrier/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'barrier',
     queries: [

--- a/basemap/layers/boundary/line.js
+++ b/basemap/layers/boundary/line.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/boundary/tileset.js
+++ b/basemap/layers/boundary/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'boundary',
     queries: [

--- a/basemap/layers/building/number.js
+++ b/basemap/layers/building/number.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'building_number',
     type: 'symbol',

--- a/basemap/layers/building/shape.js
+++ b/basemap/layers/building/shape.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'building',
     type: 'fill',

--- a/basemap/layers/building/tileset.js
+++ b/basemap/layers/building/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'building',
     queries: [

--- a/basemap/layers/highway/bridge_line.js
+++ b/basemap/layers/highway/bridge_line.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/highway/bridge_outline.js
+++ b/basemap/layers/highway/bridge_outline.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/highway/highway_construction.js
+++ b/basemap/layers/highway/highway_construction.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 // TODO:
 // recover construction styles.
 // https://raw.githubusercontent.com/baremaps/openstreetmap-vecto/7b7b9e8/layers/highway/style.js

--- a/basemap/layers/highway/highway_dash.js
+++ b/basemap/layers/highway/highway_dash.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/highway/highway_label.js
+++ b/basemap/layers/highway/highway_label.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'highway_label',
     type: 'symbol',

--- a/basemap/layers/highway/highway_line.js
+++ b/basemap/layers/highway/highway_line.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/highway/highway_outline.js
+++ b/basemap/layers/highway/highway_outline.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives =[

--- a/basemap/layers/highway/pedestrian_area.js
+++ b/basemap/layers/highway/pedestrian_area.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'pedestrian_area',
     source: 'baremaps',

--- a/basemap/layers/highway/tileset.js
+++ b/basemap/layers/highway/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'highway',
     queries: [

--- a/basemap/layers/highway/tunnel_line.js
+++ b/basemap/layers/highway/tunnel_line.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/highway/tunnel_outline.js
+++ b/basemap/layers/highway/tunnel_outline.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/labels/style.js
+++ b/basemap/layers/labels/style.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default [
     {
         id: 'dormitory_labels',

--- a/basemap/layers/landuse/background.js
+++ b/basemap/layers/landuse/background.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {withFillSortKey, asLayoutProperty, asPaintProperty} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/landuse/overlay.js
+++ b/basemap/layers/landuse/overlay.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withFillSortKey} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/landuse/tileset.js
+++ b/basemap/layers/landuse/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'landuse',
     queries: [

--- a/basemap/layers/leisure/background.js
+++ b/basemap/layers/leisure/background.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/leisure/nature_reserve.js
+++ b/basemap/layers/leisure/nature_reserve.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {withFillSortKey} from "../../utils/utils.js";
 
 let directives =  [

--- a/basemap/layers/leisure/overlay.js
+++ b/basemap/layers/leisure/overlay.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/leisure/tileset.js
+++ b/basemap/layers/leisure/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'leisure',
     queries: [

--- a/basemap/layers/man_made/bridge.js
+++ b/basemap/layers/man_made/bridge.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/man_made/pier_label.js
+++ b/basemap/layers/man_made/pier_label.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'man_made_pier_label',
     type: 'symbol',

--- a/basemap/layers/man_made/pier_line.js
+++ b/basemap/layers/man_made/pier_line.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'man_made_pier_line',
     type: 'line',

--- a/basemap/layers/man_made/tileset.js
+++ b/basemap/layers/man_made/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "man_made",
     "queries": [

--- a/basemap/layers/natural/background.js
+++ b/basemap/layers/natural/background.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/natural/overlay.js
+++ b/basemap/layers/natural/overlay.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/natural/tileset.js
+++ b/basemap/layers/natural/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "natural",
     "queries": [

--- a/basemap/layers/natural/tree.js
+++ b/basemap/layers/natural/tree.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'natural_tree',
     type: 'circle',

--- a/basemap/layers/natural/trunk.js
+++ b/basemap/layers/natural/trunk.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'natural_trunk',
     type: 'circle',

--- a/basemap/layers/natural/water.js
+++ b/basemap/layers/natural/water.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'natural_water',
     type: 'fill',

--- a/basemap/layers/ocean/overlay.js
+++ b/basemap/layers/ocean/overlay.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {withSortKeys, asLayerObject} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/ocean/tileset.js
+++ b/basemap/layers/ocean/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "ocean",
     "queries": [

--- a/basemap/layers/point/icon.js
+++ b/basemap/layers/point/icon.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/point/label.js
+++ b/basemap/layers/point/label.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSymbolSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/point/tileset.js
+++ b/basemap/layers/point/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "point",
     "queries": [

--- a/basemap/layers/power/background.js
+++ b/basemap/layers/power/background.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'power_plant',
     type: 'fill',

--- a/basemap/layers/power/cable.js
+++ b/basemap/layers/power/cable.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'power_cable',
     type: 'line',

--- a/basemap/layers/power/tileset.js
+++ b/basemap/layers/power/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "power",
     "queries": [

--- a/basemap/layers/power/tower.js
+++ b/basemap/layers/power/tower.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "power_tower",
     "type": "circle",

--- a/basemap/layers/railway/line.js
+++ b/basemap/layers/railway/line.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 export let directives = [

--- a/basemap/layers/railway/tileset.js
+++ b/basemap/layers/railway/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "railway",
     "queries": [

--- a/basemap/layers/railway/tunnel.js
+++ b/basemap/layers/railway/tunnel.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 import {directives} from './line.js'

--- a/basemap/layers/route/style.js
+++ b/basemap/layers/route/style.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 
 let directives = [

--- a/basemap/layers/route/tileset.js
+++ b/basemap/layers/route/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "route",
     "queries": [

--- a/basemap/layers/tourism/style_zoo_fill.js
+++ b/basemap/layers/tourism/style_zoo_fill.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "tourism_zoo_casing",
     "type": "line",

--- a/basemap/layers/tourism/style_zoo_line.js
+++ b/basemap/layers/tourism/style_zoo_line.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "tourism_zoo",
     "type": "line",

--- a/basemap/layers/tourism/tileset.js
+++ b/basemap/layers/tourism/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "tourism",
     "queries": [

--- a/basemap/layers/waterway/label.js
+++ b/basemap/layers/waterway/label.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     id: 'waterway_label',
     type: 'symbol',

--- a/basemap/layers/waterway/line.js
+++ b/basemap/layers/waterway/line.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "waterway",
     "type": "line",

--- a/basemap/layers/waterway/tileset.js
+++ b/basemap/layers/waterway/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "waterway",
     "queries": [

--- a/basemap/layers/waterway/tunnel_casing.js
+++ b/basemap/layers/waterway/tunnel_casing.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "waterway_tunnel_casing",
     "type": "line",

--- a/basemap/layers/waterway/tunnel_line.js
+++ b/basemap/layers/waterway/tunnel_line.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
     "id": "waterway_tunnel",
     "type": "line",

--- a/basemap/queries/globaladm0_clean.sql
+++ b/basemap/queries/globaladm0_clean.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP VIEW IF EXISTS globaladm0_z20 CASCADE;
 DROP VIEW IF EXISTS globaladm0_z19 CASCADE;
 DROP VIEW IF EXISTS globaladm0_z18 CASCADE;
@@ -19,4 +28,3 @@ DROP MATERIALIZED VIEW IF EXISTS globaladm0_z4 CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS globaladm0_z3 CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS globaladm0_z2 CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS globaladm0_z1 CASCADE;
-

--- a/basemap/queries/globaladm0_index.sql
+++ b/basemap/queries/globaladm0_index.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS globaladm0_index ON globaladm0 USING SPGIST(geom);
 CREATE INDEX IF NOT EXISTS globaladm0_z12_index ON globaladm0_z12 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS globaladm0_z11_index ON globaladm0_z11 USING SPGIST (geom);
@@ -12,5 +21,3 @@ CREATE INDEX IF NOT EXISTS globaladm0_z3_index ON globaladm0_z3 USING SPGIST (ge
 CREATE INDEX IF NOT EXISTS globaladm0_z2_index ON globaladm0_z2 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS globaladm0_z1_index ON globaladm0_z1 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS globaladm0_z0_index ON globaladm0_z0 USING SPGIST (geom);
-
-

--- a/basemap/queries/globaladm0_simplify.sql
+++ b/basemap/queries/globaladm0_simplify.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE VIEW globaladm0_z20 AS
 SELECT fid, shapegroup, shapetype, geom FROM globaladm0;
 
@@ -60,5 +69,3 @@ SELECT fid, shapegroup, shapetype, st_simplifypreservetopology(geom, 78270 / pow
 
 CREATE MATERIALIZED VIEW globaladm0_z0 AS
 SELECT fid, shapegroup, shapetype, st_simplifypreservetopology(geom, 78270 / power(2, 0)) AS geom FROM globaladm0;
-
-

--- a/basemap/queries/globaladm1_clean.sql
+++ b/basemap/queries/globaladm1_clean.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP VIEW IF EXISTS globaladm1_z20 CASCADE;
 DROP VIEW IF EXISTS globaladm1_z19 CASCADE;
 DROP VIEW IF EXISTS globaladm1_z18 CASCADE;
@@ -19,4 +28,3 @@ DROP MATERIALIZED VIEW IF EXISTS globaladm1_z4 CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS globaladm1_z3 CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS globaladm1_z2 CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS globaladm1_z1 CASCADE;
-

--- a/basemap/queries/globaladm1_index.sql
+++ b/basemap/queries/globaladm1_index.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS globaladm1_index ON globaladm1 USING SPGIST(geom);
 CREATE INDEX IF NOT EXISTS globaladm1_z12_index ON globaladm1_z12 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS globaladm1_z11_index ON globaladm1_z11 USING SPGIST (geom);
@@ -12,5 +21,3 @@ CREATE INDEX IF NOT EXISTS globaladm1_z3_index ON globaladm1_z3 USING SPGIST (ge
 CREATE INDEX IF NOT EXISTS globaladm1_z2_index ON globaladm1_z2 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS globaladm1_z1_index ON globaladm1_z1 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS globaladm1_z0_index ON globaladm1_z0 USING SPGIST (geom);
-
-

--- a/basemap/queries/globaladm1_simplify.sql
+++ b/basemap/queries/globaladm1_simplify.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE VIEW globaladm1_z20 AS
 SELECT fid, shapegroup, shapetype, geom FROM globaladm1;
 
@@ -60,5 +69,3 @@ SELECT fid, shapegroup, shapetype, st_simplifypreservetopology(geom, 78270 / pow
 
 CREATE MATERIALIZED VIEW globaladm1_z0 AS
 SELECT fid, shapegroup, shapetype, st_simplifypreservetopology(geom, 78270 / power(2, 0)) AS geom FROM globaladm1;
-
-

--- a/basemap/queries/globaladm2_clean.sql
+++ b/basemap/queries/globaladm2_clean.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP VIEW IF EXISTS globaladm2_z20 CASCADE;
 DROP VIEW IF EXISTS globaladm2_z19 CASCADE;
 DROP VIEW IF EXISTS globaladm2_z18 CASCADE;
@@ -19,4 +28,3 @@ DROP MATERIALIZED VIEW IF EXISTS globaladm2_z4 CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS globaladm2_z3 CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS globaladm2_z2 CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS globaladm2_z1 CASCADE;
-

--- a/basemap/queries/globaladm2_index.sql
+++ b/basemap/queries/globaladm2_index.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS globaladm2_index ON globaladm2 USING SPGIST(geom);
 CREATE INDEX IF NOT EXISTS globaladm2_z12_index ON globaladm2_z12 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS globaladm2_z11_index ON globaladm2_z11 USING SPGIST (geom);
@@ -12,5 +21,3 @@ CREATE INDEX IF NOT EXISTS globaladm2_z3_index ON globaladm2_z3 USING SPGIST (ge
 CREATE INDEX IF NOT EXISTS globaladm2_z2_index ON globaladm2_z2 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS globaladm2_z1_index ON globaladm2_z1 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS globaladm2_z0_index ON globaladm2_z0 USING SPGIST (geom);
-
-

--- a/basemap/queries/globaladm2_simplify.sql
+++ b/basemap/queries/globaladm2_simplify.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE VIEW globaladm2_z20 AS
 SELECT fid, shapegroup, shapetype, geom FROM globaladm2;
 
@@ -60,5 +69,3 @@ SELECT fid, shapegroup, shapetype, st_simplifypreservetopology(geom, 78270 / pow
 
 CREATE MATERIALIZED VIEW globaladm2_z0 AS
 SELECT fid, shapegroup, shapetype, st_simplifypreservetopology(geom, 78270 / power(2, 0)) AS geom FROM globaladm2;
-
-

--- a/basemap/queries/initialize.sql
+++ b/basemap/queries/initialize.sql
@@ -1,1 +1,10 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE EXTENSION IF NOT EXISTS postgis;

--- a/basemap/queries/ne_index.sql
+++ b/basemap/queries/ne_index.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS ne_10m_admin_0_antarctic_claim_limit_lines_geom_index ON ne_10m_admin_0_antarctic_claim_limit_lines USING SPGIST(geom);
 CREATE INDEX IF NOT EXISTS ne_10m_admin_0_antarctic_claims_geom_index ON ne_10m_admin_0_antarctic_claims USING SPGIST(geom);
 CREATE INDEX IF NOT EXISTS ne_10m_admin_0_boundary_lines_disputed_areas_geom_index ON ne_10m_admin_0_boundary_lines_disputed_areas USING SPGIST(geom);

--- a/basemap/queries/osm_boundary.sql
+++ b/basemap/queries/osm_boundary.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP MATERIALIZED VIEW IF EXISTS osm_boundary CASCADE;
 
 CREATE MATERIALIZED VIEW osm_boundary AS
@@ -92,4 +101,3 @@ CREATE INDEX IF NOT EXISTS osm_boundary_point_geom_z9_index ON osm_boundary_z9 U
 CREATE INDEX IF NOT EXISTS osm_boundary_point_geom_z10_index ON osm_boundary_z10 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_boundary_point_geom_z11_index ON osm_boundary_z11 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_boundary_point_geom_z12_index ON osm_boundary_z12 USING SPGIST (geom);
-

--- a/basemap/queries/osm_boundary_index.sql
+++ b/basemap/queries/osm_boundary_index.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS osm_boundary_geom_z1_index ON osm_boundary_z1 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_boundary_geom_z2_index ON osm_boundary_z2 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_boundary_geom_z3_index ON osm_boundary_z3 USING SPGIST (geom);
@@ -10,4 +19,3 @@ CREATE INDEX IF NOT EXISTS osm_boundary_geom_z9_index ON osm_boundary_z9 USING S
 CREATE INDEX IF NOT EXISTS osm_boundary_geom_z10_index ON osm_boundary_z10 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_boundary_geom_z11_index ON osm_boundary_z11 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_boundary_geom_z12_index ON osm_boundary_z12 USING SPGIST (geom);
-

--- a/basemap/queries/osm_boundary_prepare.sql
+++ b/basemap/queries/osm_boundary_prepare.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP MATERIALIZED VIEW IF EXISTS osm_boundary CASCADE;
 
 CREATE MATERIALIZED VIEW osm_boundary AS

--- a/basemap/queries/osm_boundary_simplify.sql
+++ b/basemap/queries/osm_boundary_simplify.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE VIEW osm_boundary_z20 AS
 SELECT id, tags, geom FROM osm_boundary;
 

--- a/basemap/queries/osm_highway_index.sql
+++ b/basemap/queries/osm_highway_index.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS osm_highway_geom_z1_index ON osm_highway_z1 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_highway_geom_z2_index ON osm_highway_z2 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_highway_geom_z3_index ON osm_highway_z3 USING SPGIST (geom);

--- a/basemap/queries/osm_highway_prepare.sql
+++ b/basemap/queries/osm_highway_prepare.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP MATERIALIZED VIEW IF EXISTS osm_highway CASCADE;
 
 CREATE MATERIALIZED VIEW osm_highway AS

--- a/basemap/queries/osm_highway_simplify.sql
+++ b/basemap/queries/osm_highway_simplify.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE VIEW osm_highway_z20 AS
 SELECT id, tags, geom FROM osm_highway;
 

--- a/basemap/queries/osm_landuse_index.sql
+++ b/basemap/queries/osm_landuse_index.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS osm_landuse_geom_z1_index ON osm_landuse_z1 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_landuse_geom_z2_index ON osm_landuse_z2 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_landuse_geom_z3_index ON osm_landuse_z3 USING SPGIST (geom);

--- a/basemap/queries/osm_landuse_prepare.sql
+++ b/basemap/queries/osm_landuse_prepare.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP VIEW IF EXISTS osm_landuse CASCADE;
 DROP VIEW IF EXISTS osm_landuse_residential;
 DROP VIEW IF EXISTS osm_landuse_farmland;
@@ -154,4 +163,3 @@ UNION ALL
 SELECT id, tags, geom FROM osm_landuse_water;
 
 CREATE INDEX osm_landuse_grouped_geom_idx ON osm_landuse_grouped USING GIST (geom);
-

--- a/basemap/queries/osm_landuse_simplify.sql
+++ b/basemap/queries/osm_landuse_simplify.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE VIEW osm_landuse_z20 AS
 SELECT id, tags, geom FROM osm_landuse;
 

--- a/basemap/queries/osm_linestring.sql
+++ b/basemap/queries/osm_linestring.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP VIEW IF EXISTS osm_linestring CASCADE;
 
 CREATE VIEW osm_linestring AS

--- a/basemap/queries/osm_natural_index.sql
+++ b/basemap/queries/osm_natural_index.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS osm_natural_geom_z12_index ON osm_natural_z12 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_natural_geom_z11_index ON osm_natural_z11 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_natural_geom_z10_index ON osm_natural_z10 USING SPGIST (geom);

--- a/basemap/queries/osm_natural_prepare.sql
+++ b/basemap/queries/osm_natural_prepare.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 -- ('grassland', 'heath', 'scrub', 'wood', 'bay', 'beach', 'glacier', 'mud', 'shingle', 'shoal', 'strait', 'water', 'wetland', 'bare_rock', 'sand', 'scree');
 DROP VIEW IF EXISTS osm_natural CASCADE;
 
@@ -299,5 +308,3 @@ UNION ALL
 SELECT id, tags, geom FROM osm_natural_sand
 UNION ALL
 SELECT id, tags, geom FROM osm_natural_scree;
-
-

--- a/basemap/queries/osm_natural_simplify.sql
+++ b/basemap/queries/osm_natural_simplify.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE VIEW osm_natural_z20 AS
 SELECT id, tags, geom FROM osm_natural;
 

--- a/basemap/queries/osm_nodes_clean.sql
+++ b/basemap/queries/osm_nodes_clean.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP INDEX IF EXISTS osm_nodes_tags_index;
 DROP INDEX IF EXISTS osm_nodes_geom_index;
 

--- a/basemap/queries/osm_nodes_index.sql
+++ b/basemap/queries/osm_nodes_index.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS osm_nodes_geom_z13_index ON osm_nodes_z13 USING gist (geom);
 CREATE INDEX IF NOT EXISTS osm_nodes_geom_z12_index ON osm_nodes_z12 USING gist (geom);
 CREATE INDEX IF NOT EXISTS osm_nodes_geom_z11_index ON osm_nodes_z11 USING gist (geom);

--- a/basemap/queries/osm_nodes_prepare.sql
+++ b/basemap/queries/osm_nodes_prepare.sql
@@ -1,2 +1,11 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS osm_nodes_tags_index ON osm_nodes USING gin (tags);
 CREATE INDEX IF NOT EXISTS osm_nodes_geom_index ON osm_nodes USING spgist (geom);

--- a/basemap/queries/osm_nodes_simplify.sql
+++ b/basemap/queries/osm_nodes_simplify.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE VIEW osm_nodes_z20 AS
 SELECT id, tags, geom FROM osm_nodes WHERE tags != '{}';
 

--- a/basemap/queries/osm_polygon_index.sql
+++ b/basemap/queries/osm_polygon_index.sql
@@ -1,3 +1,11 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX osm_polygon_geom_idx ON osm_polygon USING GIST (geom);
 CREATE INDEX osm_polygon_tags_idx ON osm_polygon USING GIN (tags);
-

--- a/basemap/queries/osm_polygon_prepare.sql
+++ b/basemap/queries/osm_polygon_prepare.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP MATERIALIZED VIEW IF EXISTS osm_polygon CASCADE;
 
 CREATE MATERIALIZED VIEW osm_polygon AS

--- a/basemap/queries/osm_railway_index.sql
+++ b/basemap/queries/osm_railway_index.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS osm_railway_geom_z12_index ON osm_railway_z12 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_railway_geom_z11_index ON osm_railway_z11 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_railway_geom_z10_index ON osm_railway_z10 USING SPGIST (geom);
@@ -10,4 +19,3 @@ CREATE INDEX IF NOT EXISTS osm_railway_geom_z4_index ON osm_railway_z4 USING SPG
 CREATE INDEX IF NOT EXISTS osm_railway_geom_z3_index ON osm_railway_z3 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_railway_geom_z2_index ON osm_railway_z2 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_railway_geom_z1_index ON osm_railway_z1 USING SPGIST (geom);
-

--- a/basemap/queries/osm_railway_prepare.sql
+++ b/basemap/queries/osm_railway_prepare.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP MATERIALIZED VIEW IF EXISTS osm_railway CASCADE;
 
 CREATE MATERIALIZED VIEW osm_railway AS

--- a/basemap/queries/osm_railway_simplify.sql
+++ b/basemap/queries/osm_railway_simplify.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE VIEW osm_railway_z20 AS
 SELECT id, tags, geom FROM osm_railway;
 

--- a/basemap/queries/osm_relations_clean.sql
+++ b/basemap/queries/osm_relations_clean.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP INDEX IF EXISTS osm_relations_tags_index;
 DROP INDEX IF EXISTS osm_relations_geom_index;
 

--- a/basemap/queries/osm_relations_index.sql
+++ b/basemap/queries/osm_relations_index.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS osm_relations_geom_z12_index ON osm_relations_z12 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_relations_geom_z11_index ON osm_relations_z11 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_relations_geom_z10_index ON osm_relations_z10 USING SPGIST (geom);

--- a/basemap/queries/osm_relations_prepare.sql
+++ b/basemap/queries/osm_relations_prepare.sql
@@ -1,2 +1,11 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX osm_relations_tags_index ON osm_relations USING gin (tags);
 CREATE INDEX osm_relations_geom_index ON osm_relations USING spgist (geom);

--- a/basemap/queries/osm_relations_simplify.sql
+++ b/basemap/queries/osm_relations_simplify.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE VIEW osm_relations_z20 AS
 SELECT id, tags, geom FROM osm_relations;
 

--- a/basemap/queries/osm_simplified_water_index.sql
+++ b/basemap/queries/osm_simplified_water_index.sql
@@ -1,1 +1,10 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX simplified_water_polygons_geometry_index ON simplified_water_polygons_shp USING SPGIST(geometry);

--- a/basemap/queries/osm_water_index.sql
+++ b/basemap/queries/osm_water_index.sql
@@ -1,1 +1,10 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX water_polygons_geometry_index ON water_polygons_shp USING SPGIST(geometry);

--- a/basemap/queries/osm_ways_clean.sql
+++ b/basemap/queries/osm_ways_clean.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 DROP INDEX IF EXISTS osm_ways_tags_index;
 DROP INDEX IF EXISTS osm_ways_geom_index;
 

--- a/basemap/queries/osm_ways_index.sql
+++ b/basemap/queries/osm_ways_index.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS osm_ways_z12_index ON osm_ways_z12 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_ways_z11_index ON osm_ways_z11 USING SPGIST (geom);
 CREATE INDEX IF NOT EXISTS osm_ways_z10_index ON osm_ways_z10 USING SPGIST (geom);

--- a/basemap/queries/osm_ways_prepare.sql
+++ b/basemap/queries/osm_ways_prepare.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX osm_ways_geom_index ON osm_ways USING spgist (geom);
 CREATE INDEX osm_ways_tags_index ON osm_ways USING gin (tags);
 

--- a/basemap/queries/osm_ways_simplify.sql
+++ b/basemap/queries/osm_ways_simplify.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE VIEW osm_ways_z20
 AS SELECT id, tags, geom FROM osm_ways;
 
@@ -141,5 +150,3 @@ FROM (
      ) AS osm_ways
 WHERE geom IS NOT NULL
   AND (st_area(st_envelope(geom)) > power((78270 / power(2, 1)), 2));
-
-

--- a/basemap/queries/statistics.sql
+++ b/basemap/queries/statistics.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 SELECT oid::regclass::text  AS objectname
      , relkind   AS objecttype
      , reltuples AS entries

--- a/basemap/style.js
+++ b/basemap/style.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import config from "./config.js";
 
 import background from "./layers/background/style.js";

--- a/basemap/tileset.js
+++ b/basemap/tileset.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import config from "./config.js";
 
 import aerialway from "./layers/aerialway/tileset.js";

--- a/basemap/utils/color.js
+++ b/basemap/utils/color.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export function lighten(color, percent) {
     let {r, g, b, a} = readColor(color);
     return writeColor({

--- a/basemap/utils/layer.js
+++ b/basemap/utils/layer.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default function layer(layer) {
     return {
         id: layer['id'],

--- a/basemap/utils/utils.js
+++ b/basemap/utils/utils.js
@@ -1,4 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
 
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export function withSortKeys(directives) {
     return directives
         .map(withFillSortKey)

--- a/basemap/workflow.js
+++ b/basemap/workflow.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 import config from "./config.js";
 
 export default {

--- a/examples/_geoadmin/tileset.yaml
+++ b/examples/_geoadmin/tileset.yaml
@@ -1,3 +1,13 @@
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
 id: 'contour'
 center:
   lon: 6.5743

--- a/examples/contour/README.md
+++ b/examples/contour/README.md
@@ -1,3 +1,14 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 # OpenStreetMap example
 
 This folder contains the required files to create and serve vector tiles from contour lines data. 

--- a/examples/contour/indexes.sql
+++ b/examples/contour/indexes.sql
@@ -1,0 +1,9 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.

--- a/examples/extrusion/README.md
+++ b/examples/extrusion/README.md
@@ -1,3 +1,14 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 # OpenStreetMap example
 
 This folder contains the required files to create and serve vector tiles from contour lines data. 

--- a/examples/extrusion/indexes.sql
+++ b/examples/extrusion/indexes.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_ways_gin ON osm_ways USING gin (nodes);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_relations_gin ON osm_relations USING gin (member_refs);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_nodes_gix ON osm_nodes USING GIST (geom);

--- a/examples/geocoding/README.md
+++ b/examples/geocoding/README.md
@@ -1,3 +1,14 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 # Geocoding example
 
 This folder contains the required files to create a geocoding web service. 

--- a/examples/geocoding/workflow.js
+++ b/examples/geocoding/workflow.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 const geonamesUrl = "https://download.geonames.org/export/dump/allCountries.zip";
 
 // Fetch and unzip Geonames

--- a/examples/ip-to-location/README.md
+++ b/examples/ip-to-location/README.md
@@ -1,3 +1,14 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 # IP to location example
 
 This folder contains the required files to create a web service for geo-localisation by IP address. 

--- a/examples/ip-to-location/workflow.js
+++ b/examples/ip-to-location/workflow.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 const nics = [
     {url: "https://ftp.afrinic.net/pub/dbase/afrinic.db.gz", filename: "afrinic.db"},
     {url: "https://ftp.apnic.net/apnic/whois/apnic.db.as-block.gz", filename: "apnic.db.as-block.db"},

--- a/examples/naturalearth/README.md
+++ b/examples/naturalearth/README.md
@@ -1,3 +1,14 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 # Natural Earth example
 
 This folder contains the required files to create and serve vector tiles from Natural Earth data. 

--- a/examples/naturalearth/indexes.sql
+++ b/examples/naturalearth/indexes.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX IF NOT EXISTS ne_10m_admin_0_antarctic_claim_limit_lines_gix ON ne_10m_admin_0_antarctic_claim_limit_lines USING SPGIST(geom);
 CREATE INDEX IF NOT EXISTS ne_10m_admin_0_antarctic_claims_gix ON ne_10m_admin_0_antarctic_claims USING SPGIST(geom);
 CREATE INDEX IF NOT EXISTS ne_10m_admin_0_boundary_lines_disputed_areas_gix ON ne_10m_admin_0_boundary_lines_disputed_areas USING SPGIST(geom);

--- a/examples/openstreetmap/README.md
+++ b/examples/openstreetmap/README.md
@@ -1,3 +1,14 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
 # OpenStreetMap example
 
 This folder contains the required files to create and serve vector tiles from OpenStreetMap data. 

--- a/examples/openstreetmap/indexes.sql
+++ b/examples/openstreetmap/indexes.sql
@@ -1,3 +1,12 @@
+-- Licensed under the Apache License, Version 2.0 (the License); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under the License
+-- is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+-- or implied. See the License for the specific language governing permissions and limitations under
+-- the License.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_ways_gin ON osm_ways USING gin (nodes);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_relations_gin ON osm_relations USING gin (member_refs);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS osm_nodes_gix ON osm_nodes USING GIST (geom);

--- a/examples/openstreetmap/style.js
+++ b/examples/openstreetmap/style.js
@@ -1,3 +1,14 @@
+/**
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing permissions and limitations under
+ the License.
+ **/
 export default {
   "version" : 8,
   "sources" : {


### PR DESCRIPTION
As mentioned by @julianhyde in the vote for release 0.71 we are missing the license on some files. This PR intends to corrects this.

I checked files with a missing header with
```bash 
grep "Licensed under the Apache License, Version 2.0" ./* -Lri --exclude-dir=target --exclude=\*.gz --exclude=\*.pdf --exclude=\*.pbf --exclude=\*.zip --exclude=\*.bz2 --exclude=\*.db --exclude=\*.gpkg  --exclude=\*.json --exclude=\*.txt 
```

@bchapuis I'm not sure about the license for some file (primarily ocgapi + maplibre). If you could check which license applies to those file.

Remaining files with a missing license:
```
./baremaps-cli/src/main/resources/logging.properties
./baremaps-core/src/test/resources/data.osm.xml
./baremaps-core/src/test/resources/data.osc.xml
./baremaps-core/src/main/proto/fileformat.proto
./baremaps-core/src/main/proto/osmformat.proto
./baremaps-ogcapi/src/test/resources/features.geojson
./baremaps-ogcapi/src/main/resources/initialize_ogcapi_tables.sql
./baremaps-ogcapi/src/main/resources/schemas/collections.yaml
./baremaps-ogcapi/src/main/resources/schemas/vector_layer.yaml
./baremaps-ogcapi/src/main/resources/schemas/TileJSON.yaml
./baremaps-ogcapi/src/main/resources/schemas/style-set.yaml
./baremaps-ogcapi/src/main/resources/schemas/landingPage.yaml
./baremaps-ogcapi/src/main/resources/schemas/query.yaml
./baremaps-ogcapi/src/main/resources/schemas/style-set-entry.yaml
./baremaps-ogcapi/src/main/resources/schemas/mb-style.yaml
./baremaps-ogcapi/src/main/resources/schemas/confClasses.yaml
./baremaps-ogcapi/src/main/resources/schemas/mb-layer.yaml
./baremaps-ogcapi/src/main/resources/schemas/exception.yaml
./baremaps-ogcapi/src/main/resources/schemas/extent.yaml
./baremaps-ogcapi/src/main/resources/schemas/collection.yaml
./baremaps-ogcapi/src/main/resources/schemas/link.yaml
./baremaps-ogcapi/src/main/resources/swagger.html
./baremaps-ogcapi/src/main/resources/ogcapi-openapi.yaml
./baremaps-ogcapi/src/main/resources/initialize_studio_tables.sql
./baremaps-server/src/main/resources/assets/favicon.ico
./baremaps-server/src/main/resources/assets/maplibre-gl-tile-boundaries.js
./baremaps-server/src/main/resources/assets/maplibre-gl-inspect.css
./baremaps-server/src/main/resources/assets/maplibre-gl-inspect.js
./baremaps-server/src/main/resources/assets/maplibre-gl-tile-boundaries.css

```