### PR TITLE
ogcapi, maintenance dependencies

### DIFF
--- a/baremaps-ogcapi/pom.xml
+++ b/baremaps-ogcapi/pom.xml
@@ -24,6 +24,8 @@
   <name>baremaps-ogcapi</name>
 
   <dependencies>
+    <!-- This dependency is the recommended artifact when using the openapi-generator.
+    See: https://openapi-generator.tech/docs/plugins/#dependencies-->
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser</artifactId>
@@ -152,6 +154,8 @@
                 <sortParamsByRequiredFlag>false</sortParamsByRequiredFlag>
                 <disallowAdditionalPropertiesIfNotPresent>false</disallowAdditionalPropertiesIfNotPresent>
                 <sourceFolder>src/gen/java/main</sourceFolder>
+                <!-- defaults to true, which requires org.openapitools.jackson.nullable -->
+                <openApiNullable>false</openApiNullable>
               </configOptions>
             </configuration>
           </execution>

--- a/baremaps-ogcapi/src/main/java/org/apache/baremaps/ogcapi/CollectionsResource.java
+++ b/baremaps-ogcapi/src/main/java/org/apache/baremaps/ogcapi/CollectionsResource.java
@@ -50,8 +50,10 @@ public class CollectionsResource implements CollectionsApi {
   public Response addCollection(Collection collection) {
     collection.setId(UUID.randomUUID().toString());
     jdbi.useHandle(handle -> handle
-        .createUpdate("insert into collections (id, collection) values (:id, CAST(:collection AS JSONB))")
-        .bind("id", UUID.fromString(collection.getId())).bindByType("collection", collection, COLLECTION).execute());
+        .createUpdate(
+            "insert into collections (id, collection) values (:id, CAST(:collection AS JSONB))")
+        .bind("id", UUID.fromString(collection.getId()))
+        .bindByType("collection", collection, COLLECTION).execute());
     return Response.created(URI.create("collections/" + collection.getId())).build();
   }
 
@@ -87,7 +89,8 @@ public class CollectionsResource implements CollectionsApi {
   @Override
   public Response updateCollection(UUID collectionId, Collection collection) {
     jdbi.useHandle(handle -> handle
-        .createUpdate("update collections set collection = CAST(:collection AS JSONB) where id = :id")
+        .createUpdate(
+            "update collections set collection = CAST(:collection AS JSONB) where id = :id")
         .bind("id", collectionId).bindByType("collection", collection, COLLECTION).execute());
     return Response.noContent().build();
   }

--- a/baremaps-ogcapi/src/main/java/org/apache/baremaps/ogcapi/CollectionsResource.java
+++ b/baremaps-ogcapi/src/main/java/org/apache/baremaps/ogcapi/CollectionsResource.java
@@ -50,8 +50,8 @@ public class CollectionsResource implements CollectionsApi {
   public Response addCollection(Collection collection) {
     collection.setId(UUID.randomUUID().toString());
     jdbi.useHandle(handle -> handle
-        .createUpdate("insert into collections (id, collection) values (:id, :collection)")
-        .bind("id", collection.getId()).bindByType("collection", collection, COLLECTION).execute());
+        .createUpdate("insert into collections (id, collection) values (:id, CAST(:collection AS JSONB))")
+        .bind("id", UUID.fromString(collection.getId())).bindByType("collection", collection, COLLECTION).execute());
     return Response.created(URI.create("collections/" + collection.getId())).build();
   }
 
@@ -87,7 +87,7 @@ public class CollectionsResource implements CollectionsApi {
   @Override
   public Response updateCollection(UUID collectionId, Collection collection) {
     jdbi.useHandle(handle -> handle
-        .createUpdate("update collections set collection = :collection where id = :id")
+        .createUpdate("update collections set collection = CAST(:collection AS JSONB) where id = :id")
         .bind("id", collectionId).bindByType("collection", collection, COLLECTION).execute());
     return Response.noContent().build();
   }

--- a/baremaps-ogcapi/src/test/java/org/apache/baremaps/ogcapi/ImportResourceIntegrationTest.java
+++ b/baremaps-ogcapi/src/test/java/org/apache/baremaps/ogcapi/ImportResourceIntegrationTest.java
@@ -71,6 +71,8 @@ public class ImportResourceIntegrationTest extends JerseyTest {
   }
 
   @Test
+  /** TODO: the following Ignore annotation causes the whole test to not be executed.
+   It doesn't look like it is a wanted behavior. **/
   @Ignore("Geotools has been replaced with Apache SIS")
   public void test() {
     String FILE = "features.geojson";

--- a/baremaps-ogcapi/src/test/java/org/apache/baremaps/ogcapi/ImportResourceIntegrationTest.java
+++ b/baremaps-ogcapi/src/test/java/org/apache/baremaps/ogcapi/ImportResourceIntegrationTest.java
@@ -72,8 +72,8 @@ public class ImportResourceIntegrationTest extends JerseyTest {
 
   @Test
   /**
-   * TODO: the following Ignore annotation causes the whole test to not be executed. It doesn't look
-   * like it is a wanted behavior.
+   * TODO: switch to alternative to read shapefiles and other format in the storage package of
+   * baremaps-core.
    **/
   @Ignore("Geotools has been replaced with Apache SIS")
   public void test() {

--- a/baremaps-ogcapi/src/test/java/org/apache/baremaps/ogcapi/ImportResourceIntegrationTest.java
+++ b/baremaps-ogcapi/src/test/java/org/apache/baremaps/ogcapi/ImportResourceIntegrationTest.java
@@ -71,8 +71,10 @@ public class ImportResourceIntegrationTest extends JerseyTest {
   }
 
   @Test
-  /** TODO: the following Ignore annotation causes the whole test to not be executed.
-   It doesn't look like it is a wanted behavior. **/
+  /**
+   * TODO: the following Ignore annotation causes the whole test to not be executed. It doesn't look
+   * like it is a wanted behavior.
+   **/
   @Ignore("Geotools has been replaced with Apache SIS")
   public void test() {
     String FILE = "features.geojson";

--- a/pom.xml
+++ b/pom.xml
@@ -109,8 +109,7 @@
     <version.lib.servlet>3.1.0</version.lib.servlet>
     <version.lib.slf4j>2.0.3</version.lib.slf4j>
     <version.lib.sqlite>3.39.3.0</version.lib.sqlite>
-    <version.lib.swagger>1.6.3</version.lib.swagger>
-    <version.lib.swagger-parser>2.0.24</version.lib.swagger-parser>
+    <version.lib.swagger-parser>2.1.13</version.lib.swagger-parser>
     <version.lib.testcontainers>1.17.3</version.lib.testcontainers>
     <version.lib.validation>2.0.2</version.lib.validation>
     <version.lucene>9.4.2</version.lucene>
@@ -129,7 +128,9 @@
     <version.plugin.maven-surefire-plugin>2.22.2</version.plugin.maven-surefire-plugin>
     <version.plugin.maven-surefire-plugin.provider.junit>1.3.2</version.plugin.maven-surefire-plugin.provider.junit>
     <version.plugin.nexus-staging-maven-plugin>1.6.13</version.plugin.nexus-staging-maven-plugin>
-    <version.plugin.openapi-generator-maven-plugin>5.1.0</version.plugin.openapi-generator-maven-plugin>
+    <!-- Using version [6.3.0,6.5.0] creates an issue with usage of java.util.Arrays and missing necessary import
+     similar to https://github.com/OpenAPITools/openapi-generator/issues/8408 -->
+    <version.plugin.openapi-generator-maven-plugin>6.2.1</version.plugin.openapi-generator-maven-plugin>
     <version.plugin.os-maven-plugin>1.7.0</version.plugin.os-maven-plugin>
     <version.plugin.protobuf-maven-plugin>0.6.1</version.plugin.protobuf-maven-plugin>
     <version.plugin.spotless-maven-plugin>2.33.0</version.plugin.spotless-maven-plugin>
@@ -237,16 +238,6 @@
         <groupId>io.servicetalk</groupId>
         <artifactId>servicetalk-transport-netty</artifactId>
         <version>${version.lib.servicetalk}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.swagger</groupId>
-        <artifactId>swagger-annotations</artifactId>
-        <version>${version.lib.swagger}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.swagger</groupId>
-        <artifactId>swagger-jersey2-jaxrs</artifactId>
-        <version>${version.lib.swagger}</version>
       </dependency>
       <dependency>
         <groupId>io.swagger.parser.v3</groupId>


### PR DESCRIPTION
Content:
- update swagger-parser and openapi codegen
- remove incorrect declarations in parent dependency management (quick analysis show that io.swagger:swagger-annotations, io.swagger:swagger-jersey2-jaxrs, io.swagger.parser.v3:swagger-parser do not follow the same versioning for releases. Moreover they are not all used directly as dependency by ogcapi module)
-  adapt ogcapi to newly generated code

Disclaimer: I only ran successfully the test included in baremaps-ogcapi module (one is not executed due to @Ignore, see comment) . 