### PR TITLE
Catch null pointer exception server resources

### DIFF
--- a/baremaps-server/src/main/java/org/apache/baremaps/server/DevResources.java
+++ b/baremaps-server/src/main/java/org/apache/baremaps/server/DevResources.java
@@ -158,7 +158,7 @@ public class DevResources {
     try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(path)) {
       var bytes = inputStream.readAllBytes();
       return Response.ok().entity(bytes).build();
-    } catch (IOException e) {
+    } catch (NullPointerException | IOException e) {
       return Response.status(404).build();
     }
   }

--- a/baremaps-server/src/main/java/org/apache/baremaps/server/GeocoderResources.java
+++ b/baremaps-server/src/main/java/org/apache/baremaps/server/GeocoderResources.java
@@ -104,7 +104,7 @@ public class GeocoderResources {
     try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(path)) {
       var bytes = inputStream.readAllBytes();
       return Response.ok().entity(bytes).build();
-    } catch (IOException e) {
+    } catch (NullPointerException | IOException e) {
       return Response.status(404).build();
     }
   }

--- a/baremaps-server/src/main/java/org/apache/baremaps/server/IplocResources.java
+++ b/baremaps-server/src/main/java/org/apache/baremaps/server/IplocResources.java
@@ -67,7 +67,7 @@ public class IplocResources {
     try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(path)) {
       var bytes = inputStream.readAllBytes();
       return Response.ok().entity(bytes).build();
-    } catch (IOException e) {
+    } catch (NullPointerException | IOException e) {
       return Response.status(404).build();
     }
   }

--- a/baremaps-server/src/main/java/org/apache/baremaps/server/ServerResources.java
+++ b/baremaps-server/src/main/java/org/apache/baremaps/server/ServerResources.java
@@ -107,7 +107,7 @@ public class ServerResources {
     try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(path)) {
       var bytes = inputStream.readAllBytes();
       return Response.ok().entity(bytes).build();
-    } catch (IOException e) {
+    } catch (NullPointerException | IOException e) {
       return Response.status(404).build();
     }
   }


### PR DESCRIPTION
## Bug

When making a `GET` request to an url that does not exist, we get a 500 error with a NullPointerException on the server.
This is because `getClass().getClassLoader().getResourceAsStream(path)` returns null if the path is not found which then throws the NullPointerException here:

```java
var bytes = inputStream.readAllBytes();
```

## Solution

Add a catch for a NullPointerException, and return a 404.