### PR TITLE
Fix aeroway layering order and color

### DIFF
--- a/basemap/layers/aeroway/polygon.js
+++ b/basemap/layers/aeroway/polygon.js
@@ -14,7 +14,7 @@ import {asLayerObject, withSortKeys} from "../../utils/utils.js";
 let directives = [
     {
         filter: ['==', ['geometry-type'], 'Polygon'],
-        'fill-color': 'rgba(187, 187, 204, 1.0)',
+        'fill-color': 'rgba(213, 213, 220, 1.0)',
     },
 ];
 

--- a/basemap/style.js
+++ b/basemap/style.js
@@ -70,6 +70,7 @@ export default {
     "layers": [
         background,
         power_background,
+        aeroway_polygon,
         landuse_background,
         natural_background,
         amenity_background,
@@ -98,7 +99,6 @@ export default {
         highway_bridge_line,
         highway_label,
         aeroway_line,
-        aeroway_polygon,
         route_line,
         power_cable,
         power_tower,


### PR DESCRIPTION
Fix to issue #586

- Reorder layering of aeroway polygons to be under landuse
- Add lighter gray (color from openstreet map) to aeroway polygons