### PR TITLE
Scope CLI version.txt resource file to specific package

### DIFF
--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/Baremaps.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/Baremaps.java
@@ -86,7 +86,7 @@ public class Baremaps implements Callable<Integer> {
   static class VersionProvider implements IVersionProvider {
 
     public String[] getVersion() throws Exception {
-      URL url = getClass().getResource("/version.txt");
+      URL url = Baremaps.class.getResource("version.txt");
       if (url == null) {
         return new String[] {"No version.txt file found in the classpath."};
       }

--- a/baremaps-cli/src/main/resources/org/apache/baremaps/cli/version.txt
+++ b/baremaps-cli/src/main/resources/org/apache/baremaps/cli/version.txt
@@ -1,2 +1,2 @@
-application=Baremaps
+application=Baremapsdd
 version=${project.version}


### PR DESCRIPTION
Resolves
```
 % baremaps --version
Baremaps vnull
```

For whatever reason the globbing done in the shell script or something else was making the JVM picks-up the `version.txt` from baremaps-server which is not correctly interpolated with Maven properties.
```
java -cp "$DIR/../lib/*" org.apache.baremaps.cli.Baremaps "$@"
```

This proposal scopes the resource to a package to avoid further conflicts and ensure that the resources picks-up is the version specified in baremaps-cli jar file.
```
/lib/baremaps-cli-0.7.2-SNAPSHOT.jar!/org/apache/baremaps/cli/version.txt
```
instead of classpath order resolution that serves a firstly found `version.txt` file at root of a jar.
```
/lib/<???order-based-resolution???>.jar!/version.txt
```