### PR TITLE
New cli command to edit styles locally

### DIFF
--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Map.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Map.java
@@ -18,7 +18,8 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "map", description = "Map commands.",
-    subcommands = {Init.class, Export.class, Serve.class, Dev.class}, sortOptions = false)
+    subcommands = {Init.class, Export.class, Serve.class, Dev.class, StyleCommand.class},
+    sortOptions = false)
 public class Map implements Runnable {
 
   @Override

--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/StyleCommand.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/StyleCommand.java
@@ -18,6 +18,7 @@ import static org.apache.baremaps.utils.ObjectMapperUtils.objectMapper;
 import io.servicetalk.http.netty.HttpServers;
 import io.servicetalk.http.router.jersey.HttpJerseyRouterBuilder;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -45,9 +46,9 @@ public class StyleCommand implements Callable<Integer> {
   @Mixin
   private Options options;
 
-  @Option(names = {"--tilesUrl"}, paramLabel = "TILES_URL", description = "The tiles url.",
+  @Option(names = {"--tiles"}, paramLabel = "TILES", description = "The tiles url.",
       required = true)
-  private Path tilesUrl;
+  private URL tilesUrl;
 
   @Option(names = {"--style"}, paramLabel = "STYLE", description = "The style file.",
       required = true)
@@ -89,7 +90,6 @@ public class StyleCommand implements Callable<Integer> {
           protected void configure() {
             bind("assets").to(String.class).named("directory");
             bind("viewer.html").to(String.class).named("index");
-            bind(tilesUrl).to(Path.class).named("tilesUrl");
             bind(stylePath).to(Path.class).named("style");
             bind(styleSupplier).to(styleSupplierType);
           }

--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/StyleCommand.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/StyleCommand.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.baremaps.cli.map;
+
+import static io.servicetalk.data.jackson.jersey.ServiceTalkJacksonSerializerFeature.newContextResolver;
+import static org.apache.baremaps.utils.ObjectMapperUtils.objectMapper;
+
+import io.servicetalk.http.netty.HttpServers;
+import io.servicetalk.http.router.jersey.HttpJerseyRouterBuilder;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+import org.apache.baremaps.cli.Options;
+import org.apache.baremaps.config.ConfigReader;
+import org.apache.baremaps.server.*;
+import org.apache.baremaps.vectortile.style.Style;
+import org.apache.baremaps.vectortile.style.StyleSource;
+import org.glassfish.hk2.api.TypeLiteral;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+@Command(name = "style",
+    description = "Start a development server with live reload for editing styles. Overrides the style sources.")
+public class StyleCommand implements Callable<Integer> {
+
+  private static final Logger logger = LoggerFactory.getLogger(StyleCommand.class);
+
+  @Mixin
+  private Options options;
+
+  @Option(names = {"--tilesUrl"}, paramLabel = "TILES_URL", description = "The tiles url.",
+      required = true)
+  private Path tilesUrl;
+
+  @Option(names = {"--style"}, paramLabel = "STYLE", description = "The style file.",
+      required = true)
+  private Path stylePath;
+
+  @Option(names = {"--host"}, paramLabel = "HOST", description = "The host of the server.")
+  private String host = "localhost";
+
+  @Option(names = {"--port"}, paramLabel = "PORT", description = "The port of the server.")
+  private int port = 9000;
+
+  @Override
+  public Integer call() throws Exception {
+    var configReader = new ConfigReader();
+    var objectMapper = objectMapper();
+
+    var styleSupplierType = new TypeLiteral<Supplier<Style>>() {};
+    var styleSupplier = (Supplier<Style>) () -> {
+      try {
+        var config = configReader.read(stylePath);
+        var object = objectMapper.readValue(config, Style.class);
+        var styleSource = new StyleSource("vector", tilesUrl.toString());
+        object.setSources(Map.of("baremaps", styleSource));
+        return object;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    var application = new ResourceConfig()
+        .register(CorsFilter.class)
+        .register(ChangeResource.class)
+        .register(StyleResource.class)
+        .register(ChangeResource.class)
+        .register(ClassPathResource.class)
+        .register(newContextResolver(objectMapper))
+        .register(new AbstractBinder() {
+          @Override
+          protected void configure() {
+            bind("assets").to(String.class).named("directory");
+            bind("viewer.html").to(String.class).named("index");
+            bind(tilesUrl).to(Path.class).named("tilesUrl");
+            bind(stylePath).to(Path.class).named("style");
+            bind(styleSupplier).to(styleSupplierType);
+          }
+        });
+
+    var httpService = new HttpJerseyRouterBuilder().buildBlockingStreaming(application);
+    var serverContext = HttpServers.forPort(port).listenBlockingStreamingAndAwait(httpService);
+
+    logger.info("Listening on {}", serverContext.listenAddress());
+    serverContext.awaitShutdown();
+
+    return 0;
+  }
+}

--- a/baremaps-server/src/main/java/org/apache/baremaps/server/ChangeResource.java
+++ b/baremaps-server/src/main/java/org/apache/baremaps/server/ChangeResource.java
@@ -30,6 +30,7 @@ import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseBroadcaster;
 import javax.ws.rs.sse.SseEventSink;
 import org.apache.baremaps.config.ConfigReader;
+import org.jvnet.hk2.annotations.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,8 +64,8 @@ public class ChangeResource {
    */
   @Inject
   public ChangeResource(
-      @Named("tileset") Path tileset,
-      @Named("style") Path style,
+      @Named("tileset") @Optional Path tileset,
+      @Named("style") @Optional Path style,
       Sse sse) {
     this.tileset = tileset;
     this.style = style;


### PR DESCRIPTION
Allows to edit styles with live reload while using the tiles from the production server.

Usage:

```bash
baremaps map style --style 'style.js'
```

with a custom tiles url:

```bash
baremaps map style --style 'style.js' --tilesUrl '<YOUR URL>'
```

By default the tilesUrl is set to `https://demo.baremaps.com/tiles.json`