### PR TITLE
Correct typo in configuration

### DIFF
--- a/baremaps-cli/pom.xml
+++ b/baremaps-cli/pom.xml
@@ -142,10 +142,10 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>2.0.1</version>
+        <version>2.1.0</version>
         <configuration>
           <thirdPartyFilename>THIRD-PARTY</thirdPartyFilename>
-          <excludeScopes>test</excludeScopes>
+          <excludedScopes>test</excludedScopes>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
https://www.mojohaus.org/license-maven-plugin/add-third-party-mojo.html#excludedScopes

The line was flagged as an error in Intellij, searching for a tool to lint those kind of issue yields nothing. The Intellij Maven analyzer seems to be "unique" at catching those kind of valid XML but not declared configuration of a plugin.

The dependency is updated as well but it was not a requirement.