### PR TITLE
Remove not used complementary Maven remote repositories 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -575,30 +575,6 @@
     </dependency>
   </dependencies>
 
-  <repositories>
-    <repository>
-      <id>central</id>
-      <name>Maven Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
-    </repository>
-    <repository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>geotoolkit.org</id>
-      <name>Geotoolkit.org repository</name>
-      <url>https://maven.geotoolkit.org</url>
-    </repository>
-    <repository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>geomatys</id>
-      <name>Geomatys public repository</name>
-      <url>https://nexus.geomatys.com/repository/maven-public</url>
-    </repository>
-  </repositories>
-
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Complementary remote repositories were introduced in https://github.com/apache/incubator-baremaps/pull/435/

The dependencies provided by those repositories couldn't be identified by running the following:
```
./mvnw -Dmaven.repo.local=./tmplocal package
./mvnw -Dmaven.repo.local=./tmplocal site
```

