### PR TITLE
Consistent behavior for replaceExisting file

### DIFF
--- a/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/DownloadUrl.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/DownloadUrl.java
@@ -41,29 +41,18 @@ public record DownloadUrl(String url, Path path, boolean replaceExisting) implem
     var targetUrl = new URL(url);
     var targetPath = path.toAbsolutePath();
 
-    if (isHttp(targetUrl)) {
-      if (Files.exists(targetPath) && !replaceExisting) {
-        var head = (HttpURLConnection) targetUrl.openConnection();
-        head.setInstanceFollowRedirects(true);
-        head.setRequestMethod("HEAD");
-        var contentLength = head.getContentLengthLong();
-        head.disconnect();
-        if (Files.size(targetPath) == contentLength) {
-          logger.info("Skipping download of {} to {}", url, path);
-          return;
-        }
-      }
+    if (Files.exists(targetPath) && !replaceExisting) {
+      logger.info("Skipping download of {} to {}", url, path);
+      return;
+    }
 
+    if (isHttp(targetUrl)) {
       var get = (HttpURLConnection) targetUrl.openConnection();
       get.setInstanceFollowRedirects(true);
       get.setRequestMethod("GET");
       urlDownloadToFile(get, targetPath);
       get.disconnect();
     } else if (isFtp(targetUrl)) {
-      if (Files.exists(targetPath) && !replaceExisting) {
-        logger.info("Skipping download of {} to {}", url, path);
-        return;
-      }
       urlDownloadToFile(targetUrl.openConnection(), targetPath);
     } else {
       throw new IllegalArgumentException("Unsupported URL protocol (supported: http(s)/ftp)");

--- a/baremaps-core/src/test/java/org/apache/baremaps/workflow/tasks/DownloadUrlTest.java
+++ b/baremaps-core/src/test/java/org/apache/baremaps/workflow/tasks/DownloadUrlTest.java
@@ -31,7 +31,7 @@ class DownloadUrlTest {
     var file = File.createTempFile("test", ".tmp");
     file.deleteOnExit();
     var task = new DownloadUrl("https://raw.githubusercontent.com/baremaps/baremaps/main/README.md",
-        file.toPath());
+        file.toPath(), true);
     task.execute(new WorkflowContext());
     assertTrue(Files.readString(file.toPath()).contains("Baremaps"));
   }


### PR DESCRIPTION
When replaceExisting is set to false and a file is present locally there should be no download.