### PR TITLE
Country name conversion to English

### DIFF
--- a/baremaps-core/src/main/java/org/apache/baremaps/utils/IsoCountriesUtils.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/utils/IsoCountriesUtils.java
@@ -28,7 +28,7 @@ public class IsoCountriesUtils {
   static {
     for (String iso : Locale.getISOCountries()) {
       Locale l = new Locale("", iso);
-      ISO_COUNTRIES.put(iso, l.getDisplayCountry());
+      ISO_COUNTRIES.put(iso, l.getDisplayCountry(Locale.ENGLISH));
     }
   }
 


### PR DESCRIPTION
We need to do a conversion (to English) of the name of the country recuperated by the API in order to avoid a problem of compatibility with it.