### PR TITLE
Consolidate logging dependencies

### DIFF
--- a/baremaps-cli/pom.xml
+++ b/baremaps-cli/pom.xml
@@ -61,6 +61,18 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jul</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
   </dependencies>

--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/Baremaps.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/Baremaps.java
@@ -26,11 +26,7 @@ import org.apache.baremaps.cli.map.Map;
 import org.apache.baremaps.cli.ogcapi.OgcApi;
 import org.apache.baremaps.cli.workflow.Workflow;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.slf4j.bridge.SLF4JBridgeHandler;
+import org.apache.logging.log4j.core.config.Configurator;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IVersionProvider;
@@ -42,21 +38,8 @@ import picocli.CommandLine.Option;
     sortOptions = false)
 public class Baremaps implements Callable<Integer> {
 
-  static {
-    // Apache SIS uses java.util.logging, therefore, we need to remove
-    // the existing handlers and to replace them with a bridge to slf4j.
-    SLF4JBridgeHandler.removeHandlersForRootLogger();
-    SLF4JBridgeHandler.install();
-  }
-
   @Option(names = {"-V", "--version"}, versionHelp = true, description = "Print version info.")
   boolean version;
-
-  @Override
-  public Integer call() {
-    CommandLine.usage(this, System.out);
-    return 0;
-  }
 
   public static void main(String... args) {
     // Set the log level
@@ -69,11 +52,7 @@ public class Baremaps implements Callable<Integer> {
         level = arg.substring(12).strip();
       }
       if (!"".equals(level)) {
-        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        Configuration config = ctx.getConfiguration();
-        LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
-        loggerConfig.setLevel(Level.getLevel(level));
-        ctx.updateLoggers();
+        Configurator.setRootLevel(Level.getLevel(level));
       }
     }
 
@@ -82,6 +61,13 @@ public class Baremaps implements Callable<Integer> {
         .addMixin("options", new Options());
     cmd.execute(args);
   }
+
+  @Override
+  public Integer call() {
+    CommandLine.usage(this, System.out);
+    return 0;
+  }
+
 
   static class VersionProvider implements IVersionProvider {
 

--- a/baremaps-core/pom.xml
+++ b/baremaps-core/pom.xml
@@ -90,10 +90,6 @@
       <artifactId>commons-compress</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
     </dependency>
@@ -133,10 +129,6 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jul-to-slf4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wololo</groupId>

--- a/baremaps-ogcapi/pom.xml
+++ b/baremaps-ogcapi/pom.xml
@@ -60,10 +60,6 @@
       <artifactId>baremaps-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
     </dependency>
@@ -102,10 +98,6 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <version.lib.jts>1.19.0</version.lib.jts>
     <version.lib.junit>5.7.1</version.lib.junit>
     <version.lib.junit-vintage>5.7.2</version.lib.junit-vintage>
-    <version.lib.log4j>2.19.0</version.lib.log4j>
+    <version.lib.log4j>2.20.0</version.lib.log4j>
     <version.lib.pgbulkinsert>8.1.0</version.lib.pgbulkinsert>
     <version.lib.picocli>4.6.3</version.lib.picocli>
     <version.lib.postgresql>42.5.0</version.lib.postgresql>
@@ -107,7 +107,7 @@
     <version.lib.roaringbitmap>0.9.38</version.lib.roaringbitmap>
     <version.lib.servicetalk>0.42.28</version.lib.servicetalk>
     <version.lib.servlet>3.1.0</version.lib.servlet>
-    <version.lib.slf4j>2.0.3</version.lib.slf4j>
+    <version.lib.slf4j>2.0.7</version.lib.slf4j>
     <version.lib.sqlite>3.39.3.0</version.lib.sqlite>
     <version.lib.swagger-parser>2.1.13</version.lib.swagger-parser>
     <version.lib.testcontainers>1.17.3</version.lib.testcontainers>
@@ -342,8 +342,15 @@
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-jul</artifactId>
+        <version>${version.lib.log4j}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j2-impl</artifactId>
         <version>${version.lib.log4j}</version>
+        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.lucene</groupId>
@@ -470,11 +477,6 @@
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>jul-to-slf4j</artifactId>
-        <version>${version.lib.slf4j}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${version.lib.slf4j}</version>
       </dependency>
@@ -531,13 +533,21 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-    </dependency>
+    <!-- Provide logging for any child module during test -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jul</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>


### PR DESCRIPTION
Goals:
- Keep using SLF4J API as default in modules for logging API.
- baremaps-cli use Log4j2 as logging implementation, and redirects SLF4J, JUL to it.
- Parent module provides a similar set of logging implementation for test in any child module.
- Remove any logging implementation from modules except for baremaps-cli and test scope.



Open questions:
- Should we revisit the logging API used in baremaps: SL4FJ or log4j2-api, since log4j2 is used as logging implementation?