### PR TITLE
Concat THIRD-PARTY to LICENSE in bin release

### DIFF
--- a/baremaps-cli/pom.xml
+++ b/baremaps-cli/pom.xml
@@ -23,10 +23,10 @@
   <name>baremaps-cli</name>
 
   <properties>
-    <thirdparty.directory>${project.build.directory}/generated-sources/license</thirdparty.directory>
-    <thirdparty.filename>THIRD-PARTY</thirdparty.filename>
     <license.directory>${project.build.directory}/generated-sources/license</license.directory>
     <license.filename>LICENSE</license.filename>
+    <thirdparty.directory>${project.build.directory}/generated-sources/license</thirdparty.directory>
+    <thirdparty.filename>THIRD-PARTY</thirdparty.filename>
   </properties>
 
   <dependencies>
@@ -93,33 +93,6 @@
     </resources>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
-        <executions>
-          <execution>
-            <id>default-cli</id>
-            <phase>package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <concat destfile="${license.directory}/${license.filename}"
-                        force="yes">
-                  <fileset dir="${maven.multiModuleProjectDirectory}/">
-                    <include name="LICENSE"/>
-                  </fileset>
-                  <fileset dir="${thirdparty.directory}">
-                    <include name="${thirdparty.filename}"/>
-                  </fileset>
-                </concat>
-              </target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
         <version>${version.plugin.jib-maven-plugin}</version>
@@ -132,6 +105,32 @@
             <tags>v${project.version}</tags>
           </to>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>default-cli</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <target>
+                <concat destfile="${license.directory}/${license.filename}" force="yes">
+                  <fileset dir="${maven.multiModuleProjectDirectory}/">
+                    <include name="LICENSE" />
+                  </fileset>
+                  <fileset dir="${thirdparty.directory}">
+                    <include name="${thirdparty.filename}" />
+                  </fileset>
+                </concat>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/baremaps-cli/pom.xml
+++ b/baremaps-cli/pom.xml
@@ -22,6 +22,13 @@
   <artifactId>baremaps-cli</artifactId>
   <name>baremaps-cli</name>
 
+  <properties>
+    <thirdparty.directory>${project.build.directory}/generated-sources/license</thirdparty.directory>
+    <thirdparty.filename>THIRD-PARTY</thirdparty.filename>
+    <license.directory>${project.build.directory}/generated-sources/license</license.directory>
+    <license.filename>LICENSE</license.filename>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>info.picocli</groupId>
@@ -85,6 +92,33 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>default-cli</id>
+            <phase>package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <concat destfile="${license.directory}/${license.filename}"
+                        force="yes">
+                  <fileset dir="${maven.multiModuleProjectDirectory}/">
+                    <include name="LICENSE"/>
+                  </fileset>
+                  <fileset dir="${thirdparty.directory}">
+                    <include name="${thirdparty.filename}"/>
+                  </fileset>
+                </concat>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
@@ -157,7 +191,8 @@
         <version>2.2.0</version>
         <configuration>
           <force>true</force>
-          <thirdPartyFilename>THIRD-PARTY</thirdPartyFilename>
+          <outputDirectory>${thirdparty.directory}</outputDirectory>
+          <thirdPartyFilename>${thirdparty.filename}</thirdPartyFilename>
           <!-- Template to group by license with handling of multi licensing -->
           <fileTemplate>${basedir}/licenseBundledDeps.ftl</fileTemplate>
           <!-- Only bundled bits matters https://infra.apache.org/licensing-howto.html#bundled-vs-non-bundled -->

--- a/baremaps-cli/src/assembly/bin.xml
+++ b/baremaps-cli/src/assembly/bin.xml
@@ -24,7 +24,6 @@
       <outputDirectory>.</outputDirectory>
       <includes>
         <include>DISCLAIMER-WIP</include>
-        <include>LICENSE</include>
         <include>NOTICE</include>
       </includes>
       <lineEnding>unix</lineEnding>
@@ -41,10 +40,10 @@
       <fileMode>0755</fileMode>
     </fileSet>
     <fileSet>
-      <directory>target/generated-sources/license/</directory>
+      <directory>${license.directory}</directory>
       <outputDirectory>.</outputDirectory>
       <includes>
-        <include>THIRD-PARTY</include>
+        <include>${license.filename}</include>
       </includes>
       <lineEnding>unix</lineEnding>
       <fileMode>0755</fileMode>

--- a/baremaps-cli/src/assembly/bin.xml
+++ b/baremaps-cli/src/assembly/bin.xml
@@ -27,7 +27,6 @@
         <include>NOTICE</include>
       </includes>
       <lineEnding>unix</lineEnding>
-      <fileMode>0755</fileMode>
     </fileSet>
     <fileSet>
       <directory>../.</directory>
@@ -37,7 +36,6 @@
       </includes>
       <filtered>true</filtered>
       <lineEnding>unix</lineEnding>
-      <fileMode>0755</fileMode>
     </fileSet>
     <fileSet>
       <directory>${license.directory}</directory>
@@ -46,7 +44,6 @@
         <include>${license.filename}</include>
       </includes>
       <lineEnding>unix</lineEnding>
-      <fileMode>0755</fileMode>
     </fileSet>
     <fileSet>
       <directory>src/bin</directory>


### PR DESCRIPTION
maven-license-plugin THIRD-PARTY file is appended to main LICENSE file and added to bin artifact in place of THIRD-PARTY.

Relates to: https://lists.apache.org/thread/9nxnobn29tmdylrmyyrfb3fxl3gbl60b

Resolve executable document files (README, NOTICE, DISCLAIMER-WIP, LICENSE) in binary release.

For review:
* Verify bin artifact
* Verify src artifact