### PR TITLE
TileJSONExtended implementation

### DIFF
--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Dev.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Dev.java
@@ -30,6 +30,7 @@ import org.apache.baremaps.tilestore.postgres.PostgresTileStore;
 import org.apache.baremaps.utils.PostgresUtils;
 import org.apache.baremaps.vectortile.style.Style;
 import org.apache.baremaps.vectortile.tilejson.TileJSON;
+import org.apache.baremaps.vectortile.tilejsonextended.TileJSONExtended;
 import org.apache.baremaps.vectortile.tileset.Tileset;
 import org.glassfish.hk2.api.TypeLiteral;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -103,12 +104,23 @@ public class Dev implements Callable<Integer> {
       }
     };
 
+    var tileJSONExtendedSupplierType = new TypeLiteral<Supplier<TileJSONExtended>>() {};
+    var tileJSONExtendedSupplier = (Supplier<TileJSONExtended>) () -> {
+      try {
+        var config = configReader.read(tilesetPath);
+        return objectMapper.readValue(config, TileJSONExtended.class);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
     var application = new ResourceConfig()
         .register(CorsFilter.class)
         .register(ChangeResource.class)
         .register(TileResource.class)
         .register(StyleResource.class)
         .register(TilesetResource.class)
+        .register(TileJsonExtendedResource.class)
         .register(ChangeResource.class)
         .register(ClassPathResource.class)
         .register(newContextResolver(objectMapper))
@@ -122,6 +134,7 @@ public class Dev implements Callable<Integer> {
             bind(tileStoreSupplier).to(tileStoreType);
             bind(styleSupplier).to(styleSupplierType);
             bind(tileJSONSupplier).to(tileJSONSupplierType);
+            bind(tileJSONExtendedSupplier).to(tileJSONExtendedSupplierType);
           }
         });
 

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejson/TileJSON.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejson/TileJSON.java
@@ -14,7 +14,10 @@ package org.apache.baremaps.vectortile.tilejson;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.List;
+import org.apache.baremaps.vectortile.tilejsonextended.TileJSONExtended;
 
 /**
  * TileJSON is an open standard for representing map metadata. Based on version 3.3.0.
@@ -32,11 +35,12 @@ import java.util.List;
  *      https://github.com/mapbox/tilejson-spec</a>
  */
 public class TileJSON {
+  @JsonProperty("tilejson")
   String tilejson;
   @JsonProperty("tiles")
   List<String> tiles;
   @JsonProperty("vector_layers")
-  List<VectorLayer> vectorLayers;
+  List<? extends VectorLayer> vectorLayers;
   @JsonProperty("attribution")
   String attribution;
   @JsonProperty("bounds")
@@ -71,7 +75,11 @@ public class TileJSON {
     this.tiles = tiles;
   }
 
-  public List<VectorLayer> getVectorLayers() {
+  public void setVectorLayers(
+      List<? extends VectorLayer> vectorLayers) {
+    this.vectorLayers = vectorLayers;
+  }
+  public List<? extends VectorLayer> getVectorLayers() {
     return vectorLayers;
   }
 

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejson/TileJSON.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejson/TileJSON.java
@@ -14,10 +14,7 @@ package org.apache.baremaps.vectortile.tilejson;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.List;
-import org.apache.baremaps.vectortile.tilejsonextended.TileJSONExtended;
 
 /**
  * TileJSON is an open standard for representing map metadata. Based on version 3.3.0.
@@ -79,6 +76,7 @@ public class TileJSON {
       List<? extends VectorLayer> vectorLayers) {
     this.vectorLayers = vectorLayers;
   }
+
   public List<? extends VectorLayer> getVectorLayers() {
     return vectorLayers;
   }

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejson/VectorLayer.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejson/VectorLayer.java
@@ -15,10 +15,30 @@ package org.apache.baremaps.vectortile.tilejson;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 
-public record VectorLayer(
-    @JsonProperty("id") String id,
-    @JsonProperty("fields") Map<String, String> fields,
-    @JsonProperty("description") String description,
-    @JsonProperty("maxzoom") Integer maxzoom,
-    @JsonProperty("minzoom") Integer minzoom) {
+public class VectorLayer {
+  @JsonProperty("id") String id;
+  @JsonProperty("fields") Map<String, String> fields;
+  @JsonProperty("description") String description;
+  @JsonProperty("maxzoom") Integer maxzoom;
+  @JsonProperty("minzoom") Integer minzoom;
+
+  public String getId() {
+    return id;
+  }
+
+  public Map<String, String> getFields() {
+    return fields;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public Integer getMaxzoom() {
+    return maxzoom;
+  }
+
+  public Integer getMinzoom() {
+    return minzoom;
+  }
 }

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejson/VectorLayer.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejson/VectorLayer.java
@@ -16,11 +16,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 
 public class VectorLayer {
-  @JsonProperty("id") String id;
-  @JsonProperty("fields") Map<String, String> fields;
-  @JsonProperty("description") String description;
-  @JsonProperty("maxzoom") Integer maxzoom;
-  @JsonProperty("minzoom") Integer minzoom;
+  @JsonProperty("id")
+  String id;
+  @JsonProperty("fields")
+  Map<String, String> fields;
+  @JsonProperty("description")
+  String description;
+  @JsonProperty("maxzoom")
+  Integer maxzoom;
+  @JsonProperty("minzoom")
+  Integer minzoom;
 
   public String getId() {
     return id;

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejsonextended/TileJSONExtended.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejsonextended/TileJSONExtended.java
@@ -1,0 +1,31 @@
+package org.apache.baremaps.vectortile.tilejsonextended;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import java.util.List;
+import org.apache.baremaps.vectortile.tilejson.TileJSON;
+import org.apache.baremaps.vectortile.tilejson.VectorLayer;
+
+
+/**
+ * Implementation of TileJSON with custom additional fields for baremaps.
+ */
+public class TileJSONExtended extends TileJSON {
+
+  @JsonProperty("vector_layers")
+  List<VectorLayerExtended> vectorLayersExtended;
+
+  @JsonGetter("vector_layers")
+  public List<VectorLayerExtended> getVectorLayersExtended() {
+    return this.vectorLayersExtended;
+  }
+
+  @JsonSetter("vector_layers")
+  public void setVectorLayersExtended(List<VectorLayerExtended> vectorLayersExtended) {
+    this.vectorLayersExtended = vectorLayersExtended;
+    super.setVectorLayers(vectorLayersExtended);
+  }
+
+}

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejsonextended/TileJSONExtended.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejsonextended/TileJSONExtended.java
@@ -1,12 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.apache.baremaps.vectortile.tilejsonextended;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import java.util.List;
 import org.apache.baremaps.vectortile.tilejson.TileJSON;
-import org.apache.baremaps.vectortile.tilejson.VectorLayer;
 
 
 /**

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejsonextended/VectorLayerExtended.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejsonextended/VectorLayerExtended.java
@@ -1,0 +1,17 @@
+package org.apache.baremaps.vectortile.tilejsonextended;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.baremaps.vectortile.tilejson.VectorLayer;
+import org.apache.baremaps.vectortile.tileset.TilesetQuery;
+
+public class VectorLayerExtended extends VectorLayer {
+
+  @JsonProperty("queries")
+  List<TilesetQuery> queries = new ArrayList<>();
+
+  public List<TilesetQuery> getQueries() {
+    return queries;
+  }
+}

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejsonextended/VectorLayerExtended.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tilejsonextended/VectorLayerExtended.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.apache.baremaps.vectortile.tilejsonextended;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/baremaps-core/src/test/java/org/apache/baremaps/testing/TestFiles.java
+++ b/baremaps-core/src/test/java/org/apache/baremaps/testing/TestFiles.java
@@ -50,6 +50,8 @@ public class TestFiles {
 
   public static final Path STYLE_JS = resolve("style.js");
 
+  public static final Path TILESET_JSON = resolve("style.js");
+
   public static Path resolve(String resource) {
     Path cwd = Path.of("").toAbsolutePath();
     Path pathFromRoot = Path.of("baremaps-core", "src", "test", "resources", resource);

--- a/baremaps-core/src/test/java/org/apache/baremaps/vectortile/TileSetTest.java
+++ b/baremaps-core/src/test/java/org/apache/baremaps/vectortile/TileSetTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;

--- a/baremaps-server/src/main/java/org/apache/baremaps/server/TileJsonExtendedResource.java
+++ b/baremaps-server/src/main/java/org/apache/baremaps/server/TileJsonExtendedResource.java
@@ -18,7 +18,6 @@ import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.apache.baremaps.vectortile.tilejson.TileJSON;
 import org.apache.baremaps.vectortile.tilejsonextended.TileJSONExtended;
 
 /**

--- a/baremaps-server/src/main/java/org/apache/baremaps/server/TileJsonExtendedResource.java
+++ b/baremaps-server/src/main/java/org/apache/baremaps/server/TileJsonExtendedResource.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.baremaps.server;
+
+import java.util.function.Supplier;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.apache.baremaps.vectortile.tilejson.TileJSON;
+import org.apache.baremaps.vectortile.tilejsonextended.TileJSONExtended;
+
+/**
+ * A resource that provides access to the tileJSON extended version
+ */
+@Singleton
+@javax.ws.rs.Path("/")
+public class TileJsonExtendedResource {
+
+  private final Supplier<TileJSONExtended> tileJSONSupplier;
+
+  @Inject
+  public TileJsonExtendedResource(Supplier<TileJSONExtended> tileJSONSupplier) {
+    this.tileJSONSupplier = tileJSONSupplier;
+  }
+
+  @GET
+  @javax.ws.rs.Path("tiles-extended.json")
+  @Produces(MediaType.APPLICATION_JSON)
+  public TileJSONExtended getTileset() {
+    return tileJSONSupplier.get();
+  }
+
+}


### PR DESCRIPTION
Alternative of https://github.com/apache/incubator-baremaps/pull/772 

Derived from TileJSON specification a `tiles-extended.json` with cherry-picked (i.e allow list) baremaps metadata fields out of `tileset.json` configuration file.

// POJO for baremaps-core and baremaps-server (all content is deserialized) 
  Tileset.class
// POJO strictly following TileJSON specifications for API clients.
  TileJSON.class
// POJO following TileJSON with extended fields specific to baremaps
  TileJSONExtended.class
  
In this PR `tiles.json` is always the TileJSON spec. And `tiles-extended.json` is only available in `dev` server. However the following options can be easily decided:
* Whether to provide `TileJSONExtended` in `prod` 
* Whether to serve `TileJSONExtended` in place of `tiles.json` or separately `tiles-extended.json`