### PR TITLE
Add a datasource object to the tileset

### DIFF
--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Dev.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Dev.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+import javax.sql.DataSource;
 import org.apache.baremaps.cli.Options;
 import org.apache.baremaps.config.ConfigReader;
 import org.apache.baremaps.server.*;
@@ -69,7 +70,13 @@ public class Dev implements Callable<Integer> {
     var configReader = new ConfigReader();
     var objectMapper = objectMapper();
     var tileset = objectMapper.readValue(configReader.read(this.tilesetPath), Tileset.class);
-    var datasource = PostgresUtils.createDataSource(tileset.getDatabase());
+
+    DataSource datasource;
+    if (tileset.getDataSource() != null) {
+      datasource = PostgresUtils.createDataSource(tileset.getDataSource());
+    } else {
+      datasource = PostgresUtils.createDataSource(tileset.getDatabase());
+    }
 
     var tileStoreType = new TypeLiteral<Supplier<TileStore>>() {};
     var tileStoreSupplier = (Supplier<TileStore>) () -> {

--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Dev.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Dev.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
-import javax.sql.DataSource;
 import org.apache.baremaps.cli.Options;
 import org.apache.baremaps.config.ConfigReader;
 import org.apache.baremaps.server.*;
@@ -70,13 +69,7 @@ public class Dev implements Callable<Integer> {
     var configReader = new ConfigReader();
     var objectMapper = objectMapper();
     var tileset = objectMapper.readValue(configReader.read(this.tilesetPath), Tileset.class);
-
-    DataSource datasource;
-    if (tileset.getDataSource() != null) {
-      datasource = PostgresUtils.createDataSource(tileset.getDataSource());
-    } else {
-      datasource = PostgresUtils.createDataSource(tileset.getDatabase());
-    }
+    var datasource = PostgresUtils.createDataSource(tileset.getDatabase());
 
     var tileStoreType = new TypeLiteral<Supplier<TileStore>>() {};
     var tileStoreSupplier = (Supplier<TileStore>) () -> {

--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Dev.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Dev.java
@@ -69,7 +69,7 @@ public class Dev implements Callable<Integer> {
     var configReader = new ConfigReader();
     var objectMapper = objectMapper();
     var tileset = objectMapper.readValue(configReader.read(this.tilesetPath), Tileset.class);
-    var datasource = PostgresUtils.createDataSource(tileset.getDatabase());
+    var datasource = PostgresUtils.createDataSourceFromObject(tileset.getDatabase());
 
     var tileStoreType = new TypeLiteral<Supplier<TileStore>>() {};
     var tileStoreSupplier = (Supplier<TileStore>) () -> {

--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Serve.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Serve.java
@@ -21,6 +21,7 @@ import io.servicetalk.http.router.jersey.HttpJerseyRouterBuilder;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+import javax.sql.DataSource;
 import org.apache.baremaps.cli.Options;
 import org.apache.baremaps.config.ConfigReader;
 import org.apache.baremaps.server.*;
@@ -73,7 +74,14 @@ public class Serve implements Callable<Integer> {
     var caffeineSpec = CaffeineSpec.parse(cache);
 
     var tileset = objectMapper.readValue(configReader.read(tilesetPath), Tileset.class);
-    var datasource = PostgresUtils.createDataSource(tileset.getDatabase());
+
+    DataSource datasource;
+    if (tileset.getDataSource() != null) {
+      datasource = PostgresUtils.createDataSource(tileset.getDataSource());
+    } else {
+      datasource = PostgresUtils.createDataSource(tileset.getDatabase());
+    }
+
     var tileStoreSupplierType = new TypeLiteral<Supplier<TileStore>>() {};
     var tileStore = new PostgresTileStore(datasource, tileset);
     var tileCache = new TileCache(tileStore, caffeineSpec);

--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Serve.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Serve.java
@@ -72,7 +72,7 @@ public class Serve implements Callable<Integer> {
     var configReader = new ConfigReader();
     var caffeineSpec = CaffeineSpec.parse(cache);
     var tileset = objectMapper.readValue(configReader.read(tilesetPath), Tileset.class);
-    var datasource = PostgresUtils.createDataSource(tileset.getDatabase());
+    var datasource = PostgresUtils.createDataSourceFromObject(tileset.getDatabase());
 
     var tileStoreSupplierType = new TypeLiteral<Supplier<TileStore>>() {};
     var tileStore = new PostgresTileStore(datasource, tileset);

--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Serve.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Serve.java
@@ -21,7 +21,6 @@ import io.servicetalk.http.router.jersey.HttpJerseyRouterBuilder;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
-import javax.sql.DataSource;
 import org.apache.baremaps.cli.Options;
 import org.apache.baremaps.config.ConfigReader;
 import org.apache.baremaps.server.*;
@@ -72,15 +71,8 @@ public class Serve implements Callable<Integer> {
     var objectMapper = objectMapper();
     var configReader = new ConfigReader();
     var caffeineSpec = CaffeineSpec.parse(cache);
-
     var tileset = objectMapper.readValue(configReader.read(tilesetPath), Tileset.class);
-
-    DataSource datasource;
-    if (tileset.getDataSource() != null) {
-      datasource = PostgresUtils.createDataSource(tileset.getDataSource());
-    } else {
-      datasource = PostgresUtils.createDataSource(tileset.getDatabase());
-    }
+    var datasource = PostgresUtils.createDataSource(tileset.getDatabase());
 
     var tileStoreSupplierType = new TypeLiteral<Supplier<TileStore>>() {};
     var tileStore = new PostgresTileStore(datasource, tileset);

--- a/baremaps-core/src/main/java/org/apache/baremaps/utils/PostgresUtils.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/utils/PostgresUtils.java
@@ -37,18 +37,21 @@ public final class PostgresUtils {
 
   private PostgresUtils() {}
 
-  public static DataSource createDataSource(String host, Integer port, String database,
-      String username, String password) {
+  public static DataSource createDataSource(
+      String host,
+      Integer port,
+      String database,
+      String username,
+      String password) {
     return createDataSource(
         String.format("jdbc:postgresql://%s:%s/%s?&user=%s&password=%s", host, port,
             database, username, password));
   }
 
   /**
-   * Creates a data source from a JDBC url with a pool size corresponding to the number of available
-   * processors.
+   * Creates a data source from an object, either a JDBC url or a json representation of a database.
    *
-   * @param database the database object, either a JDBC url or a {@code DataSource}
+   * @param database the database object, either a JDBC url or a json representation of a database
    * @return the data source
    */
   public static DataSource createDataSource(Object database) {
@@ -60,6 +63,12 @@ public final class PostgresUtils {
     }
   }
 
+  /**
+   * Creates a data source from a JDBC url.
+   *
+   * @param database the JDBC url
+   * @return the data source
+   */
   public static DataSource createDataSource(String database) {
     return createDataSource(database, Runtime.getRuntime().availableProcessors() * 2);
   }
@@ -83,13 +92,12 @@ public final class PostgresUtils {
   }
 
   /**
-   * Creates a data source from an object representation of a data source.
+   * Creates a data source from a json representation of a database.
    *
-   * @param datasource the object representation of a data source
+   * @param datasource the object representation of a database
    * @return the data source
    */
-  public static DataSource createDataSource(
-      Database datasource) {
+  public static DataSource createDataSource(Database datasource) {
     var config = new HikariConfig();
     if (datasource.getDataSourceClassName() != null) {
       config.setDataSourceClassName(datasource.getDataSourceClassName());

--- a/baremaps-core/src/main/java/org/apache/baremaps/utils/PostgresUtils.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/utils/PostgresUtils.java
@@ -37,6 +37,32 @@ public final class PostgresUtils {
 
   private PostgresUtils() {}
 
+
+  /**
+   * Creates a data source from an object, either a JDBC url or a json representation of a database.
+   *
+   * @param database the database object, either a JDBC url or a json representation of a database
+   * @return the data source
+   */
+  public static DataSource createDataSourceFromObject(Object database) {
+    if (database instanceof String url) {
+      return createDataSource(url);
+    } else {
+      var json = new ObjectMapper().convertValue(database, Database.class);
+      return createDataSource(json);
+    }
+  }
+
+  /**
+   * Creates a data source from parameters.
+   *
+   * @param host the host
+   * @param port the port
+   * @param database the database
+   * @param username the username
+   * @param password the password
+   * @return the data source
+   */
   public static DataSource createDataSource(
       String host,
       Integer port,
@@ -46,21 +72,6 @@ public final class PostgresUtils {
     return createDataSource(
         String.format("jdbc:postgresql://%s:%s/%s?&user=%s&password=%s", host, port,
             database, username, password));
-  }
-
-  /**
-   * Creates a data source from an object, either a JDBC url or a json representation of a database.
-   *
-   * @param database the database object, either a JDBC url or a json representation of a database
-   * @return the data source
-   */
-  public static DataSource createDataSource(Object database) {
-    if (database instanceof String url) {
-      return createDataSource(url);
-    } else {
-      var json = new ObjectMapper().convertValue(database, Database.class);
-      return createDataSource(json);
-    }
   }
 
   /**
@@ -163,8 +174,8 @@ public final class PostgresUtils {
    *
    * @param connection the JDBC connection
    * @param resource the path of the resource file
-   * @throws IOException
-   * @throws SQLException
+   * @throws IOException if an I/O error occurs
+   * @throws SQLException if a database access error occurs
    */
   public static void executeResource(Connection connection, String resource)
       throws IOException, SQLException {

--- a/baremaps-core/src/main/java/org/apache/baremaps/utils/PostgresUtils.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/utils/PostgresUtils.java
@@ -71,6 +71,57 @@ public final class PostgresUtils {
   }
 
   /**
+   * Creates a data source from an object representation of a data source.
+   *
+   * @param datasource the object representation of a data source
+   * @return the data source
+   */
+  public static DataSource createDataSource(
+      org.apache.baremaps.vectortile.tileset.DataSource datasource) {
+    var config = new HikariConfig();
+    if (datasource.getDataSourceClassName() != null) {
+      config.setDataSourceClassName(datasource.getDataSourceClassName());
+    }
+    if (datasource.getJdbcUrl() != null) {
+      config.setJdbcUrl(datasource.getJdbcUrl());
+    }
+    if (datasource.getUsername() != null) {
+      config.setUsername(datasource.getUsername());
+    }
+    if (datasource.getPassword() != null) {
+      config.setPassword(datasource.getPassword());
+    }
+    if (datasource.getAutoCommit() != null) {
+      config.setAutoCommit(datasource.getAutoCommit());
+    }
+    if (datasource.getConnectionTimeout() != null) {
+      config.setConnectionTimeout(datasource.getConnectionTimeout());
+    }
+    if (datasource.getIdleTimeout() != null) {
+      config.setInitializationFailTimeout(datasource.getIdleTimeout());
+    }
+    if (datasource.getKeepAliveTime() != null) {
+      config.setKeepaliveTime(datasource.getKeepAliveTime());
+    }
+    if (datasource.getMaxLifetime() != null) {
+      config.setMaxLifetime(datasource.getMaxLifetime());
+    }
+    if (datasource.getMinimumIdle() != null) {
+      config.setMinimumIdle(datasource.getMinimumIdle());
+    }
+    if (datasource.getMaximumPoolSize() != null) {
+      config.setMaximumPoolSize(datasource.getMaximumPoolSize());
+    }
+    if (datasource.getPoolName() != null) {
+      config.setPoolName(datasource.getPoolName());
+    }
+    if (datasource.getReadOnly() != null) {
+      config.setReadOnly(datasource.getReadOnly());
+    }
+    return new HikariDataSource(config);
+  }
+
+  /**
    * Appends the multi-queries parameter to the given JDBC URL.
    *
    * @param jdbcUrl the JDBC URL

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tileset/DataSource.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tileset/DataSource.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.baremaps.vectortile.tileset;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DataSource {
+
+  @JsonProperty("dataSourceClassName")
+  private String dataSourceClassName;
+
+  @JsonProperty("tilejson")
+  private String jdbcUrl;
+
+  @JsonProperty("username")
+  private String username;
+
+  @JsonProperty("password")
+  private String password;
+
+  @JsonProperty("autoCommit")
+  private Boolean autoCommit;
+
+  @JsonProperty("connectionTimeout")
+  private Integer connectionTimeout;
+
+  @JsonProperty("idleTimeout")
+  private Integer idleTimeout;
+
+  @JsonProperty("keepAliveTime")
+  private Integer keepAliveTime;
+
+  @JsonProperty("maxLifetime")
+  private Integer maxLifetime;
+
+  @JsonProperty("minimumIdle")
+  private Integer minimumIdle;
+
+  @JsonProperty("maximumPoolSize")
+  private Integer maximumPoolSize;
+
+  @JsonProperty("poolName")
+  private String poolName;
+
+  @JsonProperty("readOnly")
+  private Boolean readOnly;
+
+  public DataSource() {}
+
+
+  public String getDataSourceClassName() {
+    return dataSourceClassName;
+  }
+
+  public void setDataSourceClassName(String dataSourceClassName) {
+    this.dataSourceClassName = dataSourceClassName;
+  }
+
+  public String getJdbcUrl() {
+    return jdbcUrl;
+  }
+
+  public void setJdbcUrl(String jdbcUrl) {
+    this.jdbcUrl = jdbcUrl;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public Boolean getAutoCommit() {
+    return autoCommit;
+  }
+
+  public void setAutoCommit(Boolean autoCommit) {
+    this.autoCommit = autoCommit;
+  }
+
+  public Integer getConnectionTimeout() {
+    return connectionTimeout;
+  }
+
+  public void setConnectionTimeout(Integer connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
+  }
+
+  public Integer getIdleTimeout() {
+    return idleTimeout;
+  }
+
+  public void setIdleTimeout(Integer idleTimeout) {
+    this.idleTimeout = idleTimeout;
+  }
+
+  public Integer getKeepAliveTime() {
+    return keepAliveTime;
+  }
+
+  public void setKeepAliveTime(Integer keepAliveTime) {
+    this.keepAliveTime = keepAliveTime;
+  }
+
+  public Integer getMaxLifetime() {
+    return maxLifetime;
+  }
+
+  public void setMaxLifetime(Integer maxLifetime) {
+    this.maxLifetime = maxLifetime;
+  }
+
+  public Integer getMinimumIdle() {
+    return minimumIdle;
+  }
+
+  public void setMinimumIdle(Integer minimumIdle) {
+    this.minimumIdle = minimumIdle;
+  }
+
+  public Integer getMaximumPoolSize() {
+    return maximumPoolSize;
+  }
+
+  public void setMaximumPoolSize(Integer maximumPoolSize) {
+    this.maximumPoolSize = maximumPoolSize;
+  }
+
+  public String getPoolName() {
+    return poolName;
+  }
+
+  public void setPoolName(String poolName) {
+    this.poolName = poolName;
+  }
+
+  public Boolean getReadOnly() {
+    return readOnly;
+  }
+
+  public void setReadOnly(Boolean readOnly) {
+    this.readOnly = readOnly;
+  }
+}

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tileset/Database.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tileset/Database.java
@@ -13,13 +13,14 @@
 package org.apache.baremaps.vectortile.tileset;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class Database {
 
   @JsonProperty("dataSourceClassName")
   private String dataSourceClassName;
 
-  @JsonProperty("tilejson")
+  @JsonProperty("jdbcUrl")
   private String jdbcUrl;
 
   @JsonProperty("username")
@@ -159,5 +160,35 @@ public class Database {
 
   public void setReadOnly(Boolean readOnly) {
     this.readOnly = readOnly;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Database database = (Database) o;
+    return Objects.equals(dataSourceClassName, database.dataSourceClassName)
+        && Objects.equals(jdbcUrl, database.jdbcUrl) && Objects.equals(username, database.username)
+        && Objects.equals(password, database.password)
+        && Objects.equals(autoCommit, database.autoCommit)
+        && Objects.equals(connectionTimeout, database.connectionTimeout)
+        && Objects.equals(idleTimeout, database.idleTimeout)
+        && Objects.equals(keepAliveTime, database.keepAliveTime)
+        && Objects.equals(maxLifetime, database.maxLifetime)
+        && Objects.equals(minimumIdle, database.minimumIdle)
+        && Objects.equals(maximumPoolSize, database.maximumPoolSize)
+        && Objects.equals(poolName, database.poolName)
+        && Objects.equals(readOnly, database.readOnly);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(dataSourceClassName, jdbcUrl, username, password, autoCommit,
+        connectionTimeout, idleTimeout, keepAliveTime, maxLifetime, minimumIdle, maximumPoolSize,
+        poolName, readOnly);
   }
 }

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tileset/Database.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tileset/Database.java
@@ -14,7 +14,7 @@ package org.apache.baremaps.vectortile.tileset;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class DataSource {
+public class Database {
 
   @JsonProperty("dataSourceClassName")
   private String dataSourceClassName;
@@ -55,8 +55,7 @@ public class DataSource {
   @JsonProperty("readOnly")
   private Boolean readOnly;
 
-  public DataSource() {}
-
+  public Database() {}
 
   public String getDataSourceClassName() {
     return dataSourceClassName;

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tileset/Tileset.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tileset/Tileset.java
@@ -72,8 +72,12 @@ public class Tileset {
   @JsonProperty("center")
   private List<Double> center = new ArrayList<>();
 
+  @Deprecated
   @JsonProperty("database")
   private String database;
+
+  @JsonProperty("datasource")
+  private String dataSource;
 
   @JsonProperty("vector_layers")
   private List<TilesetLayer> vectorLayers = new ArrayList<>();
@@ -121,6 +125,14 @@ public class Tileset {
   public Tileset setName(String name) {
     this.name = name;
     return this;
+  }
+
+  public String getDataSource() {
+    return dataSource;
+  }
+
+  public void setDataSource(String dataSource) {
+    this.dataSource = dataSource;
   }
 
   public String getDescription() {

--- a/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tileset/Tileset.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/vectortile/tileset/Tileset.java
@@ -13,7 +13,6 @@
 package org.apache.baremaps.vectortile.tileset;
 
 
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
@@ -74,10 +73,7 @@ public class Tileset {
 
   @Deprecated
   @JsonProperty("database")
-  private String database;
-
-  @JsonProperty("datasource")
-  private String dataSource;
+  private Object database;
 
   @JsonProperty("vector_layers")
   private List<TilesetLayer> vectorLayers = new ArrayList<>();
@@ -125,14 +121,6 @@ public class Tileset {
   public Tileset setName(String name) {
     this.name = name;
     return this;
-  }
-
-  public String getDataSource() {
-    return dataSource;
-  }
-
-  public void setDataSource(String dataSource) {
-    this.dataSource = dataSource;
   }
 
   public String getDescription() {
@@ -252,7 +240,7 @@ public class Tileset {
     return this;
   }
 
-  public String getDatabase() {
+  public Object getDatabase() {
     return database;
   }
 

--- a/baremaps-core/src/main/java/org/apache/baremaps/workflow/WorkflowContext.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/workflow/WorkflowContext.java
@@ -33,7 +33,7 @@ public class WorkflowContext {
    * @return the data source
    */
   public DataSource getDataSource(Object database) {
-    return dataSources.computeIfAbsent(database, PostgresUtils::createDataSource);
+    return dataSources.computeIfAbsent(database, PostgresUtils::createDataSourceFromObject);
   }
 
 }

--- a/baremaps-core/src/main/java/org/apache/baremaps/workflow/WorkflowContext.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/workflow/WorkflowContext.java
@@ -24,7 +24,7 @@ import org.apache.baremaps.utils.PostgresUtils;
  */
 public class WorkflowContext {
 
-  private Map<String, DataSource> dataSources = new ConcurrentHashMap<>() {};
+  private Map<Object, DataSource> dataSources = new ConcurrentHashMap<>() {};
 
   /**
    * Returns the data source associated with the specified database.
@@ -32,7 +32,7 @@ public class WorkflowContext {
    * @param database the JDBC connection string to the database
    * @return the data source
    */
-  public DataSource getDataSource(String database) {
+  public DataSource getDataSource(Object database) {
     return dataSources.computeIfAbsent(database, PostgresUtils::createDataSource);
   }
 

--- a/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/ExecuteSql.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/ExecuteSql.java
@@ -22,7 +22,7 @@ import org.apache.baremaps.workflow.Task;
 import org.apache.baremaps.workflow.WorkflowContext;
 import org.apache.baremaps.workflow.WorkflowException;
 
-public record ExecuteSql(String database, Path file, boolean parallel) implements Task {
+public record ExecuteSql(Object database, Path file, boolean parallel) implements Task {
 
   @Override
   public void execute(WorkflowContext context) throws Exception {

--- a/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/ExecuteSqlScript.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/ExecuteSqlScript.java
@@ -19,7 +19,7 @@ import org.apache.baremaps.workflow.Task;
 import org.apache.baremaps.workflow.WorkflowContext;
 import org.apache.baremaps.workflow.WorkflowException;
 
-public record ExecuteSqlScript(String database, Path file) implements Task {
+public record ExecuteSqlScript(Object database, Path file) implements Task {
 
   @Override
   public void execute(WorkflowContext context) throws Exception {

--- a/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/ExportVectorTiles.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/ExportVectorTiles.java
@@ -59,6 +59,7 @@ public record ExportVectorTiles(
     var objectMapper = objectMapper();
     var tileset = objectMapper.readValue(configReader.read(this.tileset), Tileset.class);
     var datasource = context.getDataSource(tileset.getDatabase());
+
     var sourceTileStore = sourceTileStore(tileset, datasource);
     var targetTileStore = targetTileStore(tileset);
 

--- a/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/ImportGeoPackage.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/ImportGeoPackage.java
@@ -24,7 +24,7 @@ import org.apache.baremaps.workflow.WorkflowException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public record ImportGeoPackage(Path file, String database, Integer sourceSRID, Integer targetSRID)
+public record ImportGeoPackage(Path file, Object database, Integer sourceSRID, Integer targetSRID)
     implements
       Task {
 

--- a/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/ImportOpenStreetMap.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/ImportOpenStreetMap.java
@@ -41,7 +41,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public record ImportOpenStreetMap(Path file, String database, Integer databaseSrid)
+public record ImportOpenStreetMap(Path file, Object database, Integer databaseSrid)
     implements
       Task {
 

--- a/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/ImportShapefile.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/ImportShapefile.java
@@ -24,7 +24,7 @@ import org.apache.baremaps.workflow.WorkflowException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public record ImportShapefile(Path file, String database, Integer sourceSRID, Integer targetSRID)
+public record ImportShapefile(Path file, Object database, Integer sourceSRID, Integer targetSRID)
     implements
       Task {
 

--- a/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/UpdateOpenStreetMap.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/workflow/tasks/UpdateOpenStreetMap.java
@@ -44,7 +44,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public record UpdateOpenStreetMap(String database, Integer databaseSrid) implements Task {
+public record UpdateOpenStreetMap(Object database, Integer databaseSrid) implements Task {
 
   private static final Logger logger = LoggerFactory.getLogger(UpdateOpenStreetMap.class);
 


### PR DESCRIPTION
Solves #775.

The database field can either be a string corresponding to a jdbc url or an object corresponding to a hikari datasource. This allows to set additional properties, such as the maximal number of connections in the pool.