### PR TITLE
Move fonts and sprites to apache website

### DIFF
--- a/basemap/style.js
+++ b/basemap/style.js
@@ -76,8 +76,8 @@ export default {
             "url": `${config.host}/tiles.json`
         }
     },
-    "sprite": `https://tiles.baremaps.com/sprites/osm/sprite`,
-    "glyphs": "https://tiles.baremaps.com/fonts/{fontstack}/{range}.pbf",
+    "sprite": `https://baremaps.apache.org/sprites/osm/sprite`,
+    "glyphs": "https://baremaps.apache.org/fonts/{fontstack}/{range}.pbf",
     "layers": [
         background,
         power_background,

--- a/basemap/tileset.js
+++ b/basemap/tileset.js
@@ -44,7 +44,7 @@ export default {
   "tiles": [
     `${config.host}/tiles/{z}/{x}/{y}.mvt`
   ],
-  attribution: '© <a href="https://www.openstreetmap.org/">OpenStreetMap</a> © <a href="https://www.geoboundaries.org">geoBoundaries</a>',
+  attribution: '© <a href="https://www.openstreetmap.org/">OpenStreetMap</a>',
   database: config.database,
   "vector_layers": [
     aerialway,


### PR DESCRIPTION
Prior to this change, the assets were stored on an s3 bucket.