### PR TITLE
feat(example): add join postgresql with ol

### DIFF
--- a/examples/postgresql-join/init.sql
+++ b/examples/postgresql-join/init.sql
@@ -1,7 +1,7 @@
-CREATE EXTENSION postgis;
+CREATE EXTENSION IF NOT EXISTS postgis;
 
 -- Drop and create schema
-DROP SCHEMA IF EXISTS baremaps;
+DROP SCHEMA IF EXISTS baremaps CASCADE;
 CREATE SCHEMA baremaps;
 
 -- Create table baremaps.tree_type

--- a/examples/postgresql-join/init.sql
+++ b/examples/postgresql-join/init.sql
@@ -1,0 +1,46 @@
+CREATE EXTENSION postgis;
+
+-- Drop and create schema
+DROP SCHEMA IF EXISTS baremaps;
+CREATE SCHEMA baremaps;
+
+-- Create table baremaps.tree_type
+CREATE TABLE IF NOT EXISTS baremaps.tree_type (
+    id SERIAL PRIMARY KEY,
+    type VARCHAR(255) NOT NULL
+);
+
+-- Populate baremaps.tree_type with 10 different types of trees
+INSERT INTO baremaps.tree_type (type) VALUES
+    ('Oak'),
+    ('Maple'),
+    ('Pine'),
+    ('Birch'),
+    ('Spruce'),
+    ('Willow'),
+    ('Cherry'),
+    ('Poplar'),
+    ('Cypress'),
+    ('Cedar');
+
+-- Create table baremaps.point_trees
+CREATE TABLE IF NOT EXISTS baremaps.point_trees (
+    id SERIAL PRIMARY KEY,
+    geom GEOMETRY(Point, 3857) NOT NULL,
+    size INTEGER,
+    tree_type_id INTEGER REFERENCES baremaps.tree_type(id)
+);
+
+-- Populate baremaps.point_trees with 1000 random points in France
+INSERT INTO baremaps.point_trees (geom, size, tree_type_id)
+SELECT
+    ST_Transform(
+      ST_SetSRID(ST_MakePoint(
+        random() * (5.5 - 0.5) + 0.5,  -- Longitude range for France
+        random() * (51.1 - 41.1) + 41.1  -- Latitude range for France
+      ), 4326)
+    ,3857),
+    floor(random() * 100) + 1,  -- Random size between 1 and 100
+    floor(random() * 10) + 1    -- Random tree_type_id between 1 and 10
+FROM generate_series(1, 1000);  -- Number of points to generate
+

--- a/examples/postgresql-join/style.json
+++ b/examples/postgresql-join/style.json
@@ -3,16 +3,21 @@
   "sources": {
     "baremaps": {
       "type": "vector",
-      "url":"./tileset.json"
+      "url": "http://localhost:9000/tiles.json"
     }
   },
+  "center": [
+    2.6231,
+    48.8404
+  ],
+  "zoom": 10,
   "layers": [
     {
       "id": "trees",
       "type": "circle",
-      "source": "trees",
+      "source": "baremaps",
       "source-layer": "trees",
-      "minzoom": 13,
+      "minzoom": 0,
       "maxzoom": 20,
       "paint": {
         "circle-radius": 6,
@@ -24,9 +29,10 @@
           "Pine", "#e31a1c",
           "Birch", "#ff7f00",
           "Spruce", "#6a3d9a",
-          "Poplar", "#fdbf6f",  
+          "Poplar", "#fdbf6f",
           "Cypress", "#cab2d6",
-          "Cedar", "#ffff99"
+          "Cedar", "#ffff99",
+          "#000000"
         ]
       }
     }

--- a/examples/postgresql-join/style.json
+++ b/examples/postgresql-join/style.json
@@ -1,0 +1,35 @@
+{
+  "version": 8,
+  "sources": {
+    "baremaps": {
+      "type": "vector",
+      "url":"./tileset.json"
+    }
+  },
+  "layers": [
+    {
+      "id": "trees",
+      "type": "circle",
+      "source": "trees",
+      "source-layer": "trees",
+      "minzoom": 13,
+      "maxzoom": 20,
+      "paint": {
+        "circle-radius": 6,
+        "circle-color": [
+          "match",
+          ["get", "type"],
+          "Oak", "#33a02c",
+          "Maple", "#1f78b4",
+          "Pine", "#e31a1c",
+          "Birch", "#ff7f00",
+          "Spruce", "#6a3d9a",
+          "Poplar", "#fdbf6f",  
+          "Cypress", "#cab2d6",
+          "Cedar", "#ffff99"
+        ]
+      }
+    }
+  ]
+}
+

--- a/examples/postgresql-join/tileset.json
+++ b/examples/postgresql-join/tileset.json
@@ -3,12 +3,7 @@
   "tiles": [
     "http://localhost:9000/tiles/{z}/{x}/{y}.mvt"
   ],
-  "database": "jdbc:postgresql://postgis:5432/baremaps?&user=baremaps&password=baremaps",
-  "center": [
-    2.6231,
-    48.8404,
-    10 
-  ],
+  "database": "jdbc:postgresql://localhost:5432/baremaps?&user=baremaps&password=baremaps",
   "bounds": [
     -180,
     -90,
@@ -20,7 +15,7 @@
       "id": "trees",
       "queries": [
         {
-          "minzoom": 13,
+          "minzoom": 0,
           "maxzoom": 20,
           "sql": "SELECT pt.id::integer as id, jsonb_build_object('type', tt.type, 'size', pt.size) as tags, pt.geom as geom FROM baremaps.point_trees pt JOIN baremaps.tree_type tt ON pt.tree_type_id = tt.id"
         }

--- a/examples/postgresql-join/tileset.json
+++ b/examples/postgresql-join/tileset.json
@@ -1,0 +1,31 @@
+{
+  "tilejson": "2.1.0",
+  "tiles": [
+    "http://localhost:9000/tiles/{z}/{x}/{y}.mvt"
+  ],
+  "database": "jdbc:postgresql://postgis:5432/baremaps?&user=baremaps&password=baremaps",
+  "center": [
+    2.6231,
+    48.8404,
+    10 
+  ],
+  "bounds": [
+    -180,
+    -90,
+    180,
+    90
+  ],
+  "vector_layers": [
+    {
+      "id": "trees",
+      "queries": [
+        {
+          "minzoom": 13,
+          "maxzoom": 20,
+          "sql": "SELECT pt.id::integer as id, jsonb_build_object('type', tt.type, 'size', pt.size) as tags, pt.geom as geom FROM baremaps.point_trees pt JOIN baremaps.tree_type tt ON pt.tree_type_id = tt.id"
+        }
+      ]
+    }
+  ]
+}
+

--- a/examples/postgresql-join/workflow.json
+++ b/examples/postgresql-join/workflow.json
@@ -1,0 +1,15 @@
+{
+  "steps": [
+    {
+      "id": "postgresql-join",
+      "needs": [],
+      "tasks": [
+        {
+          "type": "ExecuteSqlScript",
+          "file": "./init.sql",
+          "database": "jdbc:postgresql://localhost:5432/baremaps?&user=baremaps&password=baremaps"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pr adds an example to illustrate the problem with join
cf https://github.com/apache/incubator-baremaps/issues/810


1. Add a compose with postgresql and some data
2. Add a ol mapbox example
3. Does the join inside the tileset sql statement


docker-compose up in the adde dir, 
then npm run in the ./js dir

will log **point_trees ptJOIN baremaps**

` with h65f336fd as (select * from baremaps.point_trees ptJOIN baremaps.tree_type tt ON pt.tree_type_id = tt.id where ((true)) and st_intersects(pt.geom, st_tileenvelope(13, 4156, 2829))) select st_asmvt(target, 'trees', 4096, 'geom', 'id') from (select id::integer as id, (jsonb_build_object('type', tt.type, 'size', pt.size) ||  jsonb_build_object('geometry', lower(replace(st_geometrytype(pt.geom), 'ST_', '')))) as tags, st_asmvtgeom(pt.geom, st_tileenvelope(13, 4156, 2829), 4096, 256, true) as geom from h65f336fd ) as target
`