### PR TITLE
Remove the dependency to proj4j-epsg

### DIFF
--- a/DISCLAIMER-WIP
+++ b/DISCLAIMER-WIP
@@ -10,7 +10,6 @@ releases may have incomplete or un-reviewed licensing conditions. What follows i
 the project is currently aware of (this list is likely to be incomplete):
 
  * Releases may have incomplete licensing conditions.
- * Releases contain the incompatible proj4j-epsg dependency.
  * Releases contain excerpts of the OpenStreetMap data.
  * Releases contain excerpts of the Natural Earth data.
  * Releases contain excerpts of the GeoNames data.

--- a/NOTICE
+++ b/NOTICE
@@ -51,10 +51,6 @@ Open Data Commons Open Database License (ODbL).
 Please visit the following URL for the full text of the ODbL license:
 https://opendatacommons.org/licenses/odbl/1.0/
 
-This product includes data from the European Petroleum Survey Group (EPSG).
-Please visit the following URL for the full text of the EPSG Terms of Use:
-https://epsg.org/terms-of-use.html
-
 This product includes test data derived from NaturalEarth.
 Public Domain.
 Please visit the following URL for the full text of the terms of use:

--- a/baremaps-cli/src/license/override.properties
+++ b/baremaps-cli/src/license/override.properties
@@ -121,7 +121,6 @@ org.latencyutils--LatencyUtils--2.0.3=Public Domain, per Creative Commons CC0
 org.locationtech.jts--jts-core--1.19.0=Eclipse Distribution License 1.0
 org.locationtech.jts.io--jts-io-common--1.19.0=Eclipse Distribution License 1.0
 org.locationtech.proj4j--proj4j--1.3.0=Apache License 2.0
-org.locationtech.proj4j--proj4j-epsg--1.3.0=Apache License 2.0; EPSG database distribution license
 org.locationtech.spatial4j--spatial4j--0.8=Apache License 2.0
 org.ow2.asm--asm--7.2=BSD 3-Clause License
 org.ow2.asm--asm-analysis--7.2=BSD 3-Clause License

--- a/baremaps-core/pom.xml
+++ b/baremaps-core/pom.xml
@@ -118,11 +118,6 @@ limitations under the License.
       <groupId>org.locationtech.proj4j</groupId>
       <artifactId>proj4j</artifactId>
     </dependency>
-    <!-- TODO: Remove this dependency due to license incompatibility -->
-    <dependency>
-      <groupId>org.locationtech.proj4j</groupId>
-      <artifactId>proj4j-epsg</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>

--- a/baremaps-core/src/main/java/org/apache/baremaps/utils/CRSUtils.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/utils/CRSUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.baremaps.utils;
+
+import org.locationtech.proj4j.CRSFactory;
+import org.locationtech.proj4j.CoordinateReferenceSystem;
+
+/**
+ * Utility methods for creating coordinate reference systems.
+ * <p>
+ * This method first looks into a minimal set of crs definitions that are hardcoded in the
+ * application. This includes the "WSG 84" and "WGS 84 / Pseudo-Mercator" coordinate reference
+ * systems.
+ * <p>
+ * Then, it tries to create a CRS from the EPSG code that may be stored in the proj4/nad/epsg
+ * resource file of the proj4j-epsg module.
+ * <p>
+ * The proj4j-epsg module is not included in baremaps by default due to licensing issues. It can be
+ * added to the classpath to enable the creation of CRS from EPSG codes.
+ */
+public class CRSUtils {
+
+  private static final CRSFactory CRS_FACTORY = new CRSFactory();
+
+  private static final CoordinateReferenceSystem WGS_84 =
+      CRS_FACTORY.createFromParameters("WGS 84", new String[] {
+          "+proj=longlat",
+          "+datum=WGS84",
+          "+no_defs"
+      });
+
+  private static final CoordinateReferenceSystem WGS_84_PSEUDO_MERCATOR =
+      CRS_FACTORY.createFromParameters("WGS 84 / Pseudo-Mercator", new String[] {
+          "+proj=merc",
+          "+a=6378137",
+          "+b=6378137",
+          "+lat_ts=0.0",
+          "+lon_0=0.0",
+          "+x_0=0.0",
+          "+y_0=0",
+          "+k=1.0",
+          "+units=m",
+          "+nadgrids=@null",
+          "+wktext",
+          "+no_defs"
+      });
+
+  /**
+   * Creates a coordinate reference system from the provided SRID.
+   *
+   * @param srid the SRID
+   * @return the coordinate reference system
+   */
+  public static CoordinateReferenceSystem createFromSrid(int srid) {
+    switch (srid) {
+      case 4326:
+        return WGS_84;
+      case 3857:
+        return WGS_84_PSEUDO_MERCATOR;
+      default:
+        return CRS_FACTORY.createFromName(String.format("EPSG:%s", srid));
+    }
+  }
+}

--- a/baremaps-core/src/main/java/org/apache/baremaps/utils/GeometryUtils.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/utils/GeometryUtils.java
@@ -77,10 +77,8 @@ public class GeometryUtils {
    */
   public static CoordinateTransform coordinateTransform(Integer sourceSrid, Integer targetSrid) {
     CRSFactory crsFactory = new CRSFactory();
-    CoordinateReferenceSystem sourceCRS =
-        crsFactory.createFromName(String.format("EPSG:%d", sourceSrid));
-    CoordinateReferenceSystem targetCRS =
-        crsFactory.createFromName(String.format("EPSG:%d", targetSrid));
+    CoordinateReferenceSystem sourceCRS = CRSUtils.createFromSrid(sourceSrid);
+    CoordinateReferenceSystem targetCRS = CRSUtils.createFromSrid(targetSrid);
     CoordinateTransformFactory coordinateTransformFactory = new CoordinateTransformFactory();
     return coordinateTransformFactory.createTransform(sourceCRS, targetCRS);
   }

--- a/baremaps-core/src/main/java/org/apache/baremaps/utils/ProjectionTransformer.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/utils/ProjectionTransformer.java
@@ -24,7 +24,6 @@ import java.util.stream.Stream;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 import org.locationtech.jts.geom.util.GeometryTransformer;
-import org.locationtech.proj4j.CRSFactory;
 import org.locationtech.proj4j.CoordinateTransform;
 import org.locationtech.proj4j.ProjCoordinate;
 import org.slf4j.Logger;
@@ -56,7 +55,7 @@ public class ProjectionTransformer extends GeometryTransformer {
     this.targetSrid = targetSrid;
     this.transform = GeometryUtils.coordinateTransform(sourceSrid, targetSrid);
 
-    var targetCRS = new CRSFactory().createFromName(String.format("EPSG:%s", targetSrid));
+    var targetCRS = CRSUtils.createFromSrid(targetSrid);
     var lonlatTranform = GeometryUtils.coordinateTransform(4326, sourceSrid);
     min = lonlatTranform
         .transform(new ProjCoordinate(Math.toDegrees(targetCRS.getProjection().getMinLongitude()),

--- a/baremaps-core/src/test/java/org/apache/baremaps/openstreetmap/geometry/EntityDataTypeGeometryBuilderTest.java
+++ b/baremaps-core/src/test/java/org/apache/baremaps/openstreetmap/geometry/EntityDataTypeGeometryBuilderTest.java
@@ -34,6 +34,7 @@ import org.apache.baremaps.openstreetmap.model.Node;
 import org.apache.baremaps.openstreetmap.model.Relation;
 import org.apache.baremaps.openstreetmap.model.Way;
 import org.apache.baremaps.openstreetmap.store.MockDataMap;
+import org.apache.baremaps.utils.CRSUtils;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -52,7 +53,7 @@ class EntityDataTypeGeometryBuilderTest {
 
   static final CRSFactory CRS_FACTORY = new CRSFactory();
 
-  static final CoordinateReferenceSystem EPSG_4326 = CRS_FACTORY.createFromName("EPSG:4326");
+  static final CoordinateReferenceSystem EPSG_4326 = CRSUtils.createFromSrid(4326);
 
   static final CoordinateTransform COORDINATE_TRANSFORM = new CoordinateTransform() {
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -357,11 +357,6 @@ limitations under the License.
         <version>${version.lib.proj4j}</version>
       </dependency>
       <dependency>
-        <groupId>org.locationtech.proj4j</groupId>
-        <artifactId>proj4j-epsg</artifactId>
-        <version>${version.lib.proj4j}</version>
-      </dependency>
-      <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
         <version>${version.lib.postgresql}</version>


### PR DESCRIPTION
This removal aims at making the future releases of Baremaps compliant with Apache guidelines.

The Apache SIS documentation contains a good documentation on how to deal with EPSG. Baremaps now includes two CRS definitions in the source code (WGS 84 and WGS 84 / Pseudo-Mercator), so the EPSG database is not necessary anymore. One can still decide to add the EPSG database in the classpath afterward if needed.

https://sis.apache.org/epsg.html 

