### PR TITLE
Fix NoSuchFileException when run `baremaps workflow execute --file examples/ip-to-location/workflow.js`

### DIFF
--- a/examples/ip-to-location/workflow.js
+++ b/examples/ip-to-location/workflow.js
@@ -70,7 +70,7 @@ export default {"steps": [
                 return {
                     type: "DecompressFile",
                     source: `downloads/${nic.filename}.gz`,
-                    target: "archives/ripe.db",
+                    target: `archives/${nic.filename}`,
                     compression: "gzip"
                 }
             }),


### PR DESCRIPTION
When executing this workflow, 
```bash
cd examples/ip-to-location
baremaps workflow execute --file workflow.js
```
an exceptions will be thrown:
```java
java.util.concurrent.CompletionException: org.apache.baremaps.workflow.WorkflowException: org.apache.baremaps.openstreetmap.stream.StreamException: java.nio.file.NoSuchFileException: archives/altdb.db
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)
	at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:791)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:842)
Caused by: org.apache.baremaps.workflow.WorkflowException: org.apache.baremaps.openstreetmap.stream.StreamException: java.nio.file.NoSuchFileException: archives/altdb.db
	at org.apache.baremaps.workflow.WorkflowExecutor.lambda$createStep$3(WorkflowExecutor.java:172)
	at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:787)
	... 4 more
Caused by: org.apache.baremaps.openstreetmap.stream.StreamException: java.nio.file.NoSuchFileException: archives/altdb.db
	at org.apache.baremaps.workflow.tasks.CreateIplocIndex.lambda$execute$0(CreateIplocIndex.java:94)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:290)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:754)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:686)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateParallel(ForEachOps.java:159)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateParallel(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:765)
	at org.apache.baremaps.workflow.tasks.CreateIplocIndex.execute(CreateIplocIndex.java:89)
	at org.apache.baremaps.workflow.WorkflowExecutor.lambda$createStep$3(WorkflowExecutor.java:167)
	... 5 more
Caused by: java.nio.file.NoSuchFileException: archives/altdb.db
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:380)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:432)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:422)
	at java.base/java.nio.file.Files.newInputStream(Files.java:160)
	at org.apache.baremaps.workflow.tasks.CreateIplocIndex.lambda$execute$0(CreateIplocIndex.java:90)
	... 19 more
```

This is because during the `DecompressFile` phase, the files are extracted to the same file every time.