### PR TITLE
fix ERROR: column t.tags does not exist

### DIFF
--- a/examples/extrusion/tileset.json
+++ b/examples/extrusion/tileset.json
@@ -24,7 +24,7 @@
         {
           "minzoom": 12,
           "maxzoom": 20,
-          "sql": "SELECT id, tags || jsonb_build_object('building:height', (CASE WHEN tags ->> 'building:levels' ~ '^[0-9\\\\.]+$' THEN tags ->> 'building:levels' ELSE '1' END)::real * 3), geom FROM osm_ways WHERE tags ? 'building'"
+          "sql": "SELECT id, tags || jsonb_build_object('building:height', (CASE WHEN tags ->> 'building:levels' ~ '^[0-9\\\\.]+$' THEN tags ->> 'building:levels' ELSE '1' END)::real * 3) as tags, geom FROM osm_ways WHERE tags ? 'building'"
         }
       ]
     }


### PR DESCRIPTION
When you [extrude the vector tiles from OSM data](https://baremaps.incubator.apache.org/documentation/examples/extrusion/) and view it in a browser, an EXCEPTION will be thrown as below:


```java
Caused by: org.apache.baremaps.tilestore.TileStoreException: Failed to execute statement: HikariProxyPreparedStatement@2073309203 wrapping SELECT (SELECT ST_AsMVT(mvtGeom.*, 'building') FROM (SELECT ST_AsMVTGeom(t.geom, ST_TileEnvelope(('14'::int4), ('8198'::int4), ('5447'::int4))) AS geom, t.tags - 'id' AS tags, t.id AS id FROM (SELECT id, tags || jsonb_build_object('building:height', (CASE WHEN tags ->> 'building:levels' ~ '^[0-9\\.]+$' THEN tags ->> 'building:levels' ELSE '1' END)::real * 3), geom FROM osm_ways WHERE tags ? 'building') AS t WHERE t.geom IS NOT NULL AND t.geom && ST_TileEnvelope(('14'::int4), ('8198'::int4), ('5447'::int4), margin => (64.0/4096))) AS mvtGeom) AS mvtTile
	at org.apache.baremaps.tilestore.postgres.PostgresTileStore.read(PostgresTileStore.java:103)
	... 13 more
Caused by: org.postgresql.util.PSQLException: ERROR: column t.tags does not exist
  Position: 120
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2725)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2412)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:371)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:502)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:419)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:194)
	at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:137)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
	at org.apache.baremaps.tilestore.postgres.PostgresTileStore.read(PostgresTileStore.java:96)
	... 13 more
```

This is because the expression of SQL desires an alias. Maybe it can work well in some special version of Postgre, but for better compatibility, I think a SQL with clear semantics is more highly regarded.

