### PR TITLE
Depend on s3 instead of the whole aws bundle

### DIFF
--- a/baremaps-geoparquet/pom.xml
+++ b/baremaps-geoparquet/pom.xml
@@ -45,5 +45,9 @@
       <groupId>org.locationtech.proj4j</groupId>
       <artifactId>proj4j</artifactId>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,12 @@ limitations under the License.
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-aws</artifactId>
         <version>${version.lib.hadoop}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>bundle</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
This change reduces the size of the binary distribution by about 400MB.