### PR TITLE
Fix issues identified when executing the workflow

### DIFF
--- a/baremaps-core/src/main/java/org/apache/baremaps/workflow/WorkflowContext.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/workflow/WorkflowContext.java
@@ -64,7 +64,7 @@ public class WorkflowContext {
   }
 
   public Map<Long, Coordinate> getCoordinateMap() throws IOException {
-    return DataConversions.asMap(getMemoryAlignedDataMap("coordinates", new LonLatDataType()));
+    return DataConversions.asMap(getMonotonicDataMap("coordinates", new LonLatDataType()));
   }
 
   public Map<Long, List<Long>> getReferenceMap() throws IOException {

--- a/baremaps-data/src/main/java/org/apache/baremaps/data/collection/DataConversions.java
+++ b/baremaps-data/src/main/java/org/apache/baremaps/data/collection/DataConversions.java
@@ -270,13 +270,7 @@ public class DataConversions {
 
     @Override
     public V get(Object key) {
-      if (map instanceof MemoryAlignedDataMap) {
-        return map.get(key);
-      } else if (map instanceof IndexedDataMap) {
-        return map.get(key);
-      } else {
-        return super.get(key);
-      }
+      return map.get(key);
     }
 
     @Override

--- a/baremaps-data/src/main/java/org/apache/baremaps/data/collection/MonotonicDataMap.java
+++ b/baremaps-data/src/main/java/org/apache/baremaps/data/collection/MonotonicDataMap.java
@@ -149,7 +149,6 @@ public class MonotonicDataMap<E> implements DataMap<Long, E> {
         .iterator();
   }
 
-
   /** {@inheritDoc} */
   @Override
   public long size() {

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,12 @@ limitations under the License.
         <groupId>mil.nga.geopackage</groupId>
         <artifactId>geopackage</artifactId>
         <version>${version.lib.geopackage}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>net.ripe.ipresource</groupId>


### PR DESCRIPTION
- DataConversions should always call the wrapped methods
- Only one log provider should be included in the project
- Use MonotonicDataMap for coordinates and references