### PR TITLE
Fix performance issue on PG Tile Store (#909)

### DIFF
--- a/baremaps-core/src/main/java/org/apache/baremaps/tilestore/postgres/PostgresTileStore.java
+++ b/baremaps-core/src/main/java/org/apache/baremaps/tilestore/postgres/PostgresTileStore.java
@@ -165,8 +165,8 @@ public class PostgresTileStore implements TileStore<ByteBuffer> {
               .replace("$zoom", String.valueOf(zoom));
           var querySqlWithParams = String.format(
               "SELECT ST_AsMVTGeom(t.geom, ST_TileEnvelope(?, ?, ?)) AS geom, t.tags - 'id' AS tags, t.id AS id "
-                  + "FROM (%s) AS t WHERE t.geom IS NOT NULL "
-                  + "AND t.geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096))",
+                  + "FROM ((%s) AS t1 WHERE t1.geom IS NOT NULL "
+                  + "AND t1.geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096))) as t",
               querySql);
           layerSql.append(querySqlWithParams);
 

--- a/baremaps-core/src/test/java/org/apache/baremaps/tilestore/postgres/PostgresTileStoreTest.java
+++ b/baremaps-core/src/test/java/org/apache/baremaps/tilestore/postgres/PostgresTileStoreTest.java
@@ -40,7 +40,7 @@ class PostgresTileStoreTest {
             List.of(new TilesetQuery(0, 20, "SELECT id, tags, geom FROM table")))));
     var query = PostgresTileStore.prepareQuery(tileset, 10);
     assertEquals(
-        "SELECT (SELECT ST_AsMVT(mvtGeom.*, 'a') FROM (SELECT ST_AsMVTGeom(t.geom, ST_TileEnvelope(?, ?, ?)) AS geom, t.tags - 'id' AS tags, t.id AS id FROM ((SELECT id, tags, geom FROM table as t1 WHERE t1.geom IS NOT NULL AND t1.geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096))) AS t) AS mvtGeom) || (SELECT ST_AsMVT(mvtGeom.*, 'b') FROM (SELECT ST_AsMVTGeom(t.geom, ST_TileEnvelope(?, ?, ?)) AS geom, t.tags - 'id' AS tags, t.id AS id FROM (SELECT id, tags, geom FROM table as t1 WHERE t1.geom IS NOT NULL AND t1.geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096))) AS t) AS mvtGeom) AS mvtTile",
+        "SELECT (SELECT ST_AsMVT(mvtGeom.*, 'a') FROM (SELECT ST_AsMVTGeom(t.geom, ST_TileEnvelope(?, ?, ?)) AS geom, t.tags - 'id' AS tags, t.id AS id FROM ((SELECT id, tags, geom FROM table) AS t1 WHERE t1.geom IS NOT NULL AND t1.geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096))) as t) AS mvtGeom) || (SELECT ST_AsMVT(mvtGeom.*, 'b') FROM (SELECT ST_AsMVTGeom(t.geom, ST_TileEnvelope(?, ?, ?)) AS geom, t.tags - 'id' AS tags, t.id AS id FROM ((SELECT id, tags, geom FROM table) AS t1 WHERE t1.geom IS NOT NULL AND t1.geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096))) as t) AS mvtGeom) AS mvtTile",
         query.sql());
   }
 }

--- a/baremaps-core/src/test/java/org/apache/baremaps/tilestore/postgres/PostgresTileStoreTest.java
+++ b/baremaps-core/src/test/java/org/apache/baremaps/tilestore/postgres/PostgresTileStoreTest.java
@@ -40,7 +40,7 @@ class PostgresTileStoreTest {
             List.of(new TilesetQuery(0, 20, "SELECT id, tags, geom FROM table")))));
     var query = PostgresTileStore.prepareQuery(tileset, 10);
     assertEquals(
-        "SELECT (SELECT ST_AsMVT(mvtGeom.*, 'a') FROM (SELECT ST_AsMVTGeom(t.geom, ST_TileEnvelope(?, ?, ?)) AS geom, t.tags - 'id' AS tags, t.id AS id FROM (SELECT id, tags, geom FROM table) AS t WHERE t.geom IS NOT NULL AND t.geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096))) AS mvtGeom) || (SELECT ST_AsMVT(mvtGeom.*, 'b') FROM (SELECT ST_AsMVTGeom(t.geom, ST_TileEnvelope(?, ?, ?)) AS geom, t.tags - 'id' AS tags, t.id AS id FROM (SELECT id, tags, geom FROM table) AS t WHERE t.geom IS NOT NULL AND t.geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096))) AS mvtGeom) AS mvtTile",
+        "SELECT (SELECT ST_AsMVT(mvtGeom.*, 'a') FROM (SELECT ST_AsMVTGeom(t.geom, ST_TileEnvelope(?, ?, ?)) AS geom, t.tags - 'id' AS tags, t.id AS id FROM ((SELECT id, tags, geom FROM table as t1 WHERE t1.geom IS NOT NULL AND t1.geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096))) AS t) AS mvtGeom) || (SELECT ST_AsMVT(mvtGeom.*, 'b') FROM (SELECT ST_AsMVTGeom(t.geom, ST_TileEnvelope(?, ?, ?)) AS geom, t.tags - 'id' AS tags, t.id AS id FROM (SELECT id, tags, geom FROM table as t1 WHERE t1.geom IS NOT NULL AND t1.geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096))) AS t) AS mvtGeom) AS mvtTile",
         query.sql());
   }
 }


### PR DESCRIPTION
Fix #909 - change the position of the geometry filter in the query to have a better usage of indexes.