### PR TITLE
Generate different queries depending on the postgresql version

### DIFF
--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Dev.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Dev.java
@@ -87,6 +87,7 @@ public class Dev implements Callable<Integer> {
     var objectMapper = objectMapper();
     var tileset = objectMapper.readValue(configReader.read(this.tilesetPath), Tileset.class);
     var datasource = PostgresUtils.createDataSourceFromObject(tileset.getDatabase());
+    var postgresVersion = PostgresUtils.getPostgresVersion(datasource);
 
     var tilesetSupplier = (Supplier<Tileset>) () -> {
       try {
@@ -99,7 +100,7 @@ public class Dev implements Callable<Integer> {
 
     var tileStoreSupplier = (Supplier<TileStore<ByteBuffer>>) () -> {
       var tileJSON = tilesetSupplier.get();
-      return new PostgresTileStore(datasource, tileJSON);
+      return new PostgresTileStore(datasource, tileJSON, postgresVersion);
     };
 
     var styleSupplier = (Supplier<Style>) () -> {

--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Serve.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Serve.java
@@ -93,9 +93,10 @@ public class Serve implements Callable<Integer> {
     var caffeineSpec = CaffeineSpec.parse(cache);
     var tileset = objectMapper.readValue(configReader.read(tilesetPath), Tileset.class);
     var datasource = PostgresUtils.createDataSourceFromObject(tileset.getDatabase());
+    var postgresVersion = PostgresUtils.getPostgresVersion(datasource);
 
     try (
-        var tileStore = new PostgresTileStore(datasource, tileset);
+        var tileStore = new PostgresTileStore(datasource, tileset, postgresVersion);
         var tileCache = new VectorTileCache(tileStore, caffeineSpec)) {
 
       var tileStoreSupplier = (Supplier<TileStore<ByteBuffer>>) () -> tileCache;

--- a/baremaps-core/src/test/java/org/apache/baremaps/tilestore/postgres/PostgresTileStoreTest.java
+++ b/baremaps-core/src/test/java/org/apache/baremaps/tilestore/postgres/PostgresTileStoreTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.baremaps.maplibre.tileset.Tileset;
 import org.apache.baremaps.maplibre.tileset.TilesetLayer;
 import org.apache.baremaps.maplibre.tileset.TilesetQuery;
+import org.apache.baremaps.tilestore.TileCoord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +48,7 @@ class PostgresTileStoreTest {
   @Test
   void prepareNewQuery() {
     var postgresTileStore = new PostgresTileStore(null, tileset, 16);
-    var query = postgresTileStore.prepareQuery(10);
+    var query = postgresTileStore.prepareQuery(new TileCoord(1, 1, 10));
     assertEquals(
         "SELECT (SELECT ST_AsMVT(mvtGeom.*, 'a') FROM (SELECT mvtData.id AS id, mvtData.tags - 'id' AS tags, ST_AsMVTGeom(mvtData.geom, ST_TileEnvelope(?, ?, ?)) AS geom FROM (SELECT id, tags, geom FROM table) AS mvtData WHERE mvtData.geom IS NOT NULL AND mvtData.geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096)) ) AS mvtGeom) || (SELECT ST_AsMVT(mvtGeom.*, 'b') FROM (SELECT mvtData.id AS id, mvtData.tags - 'id' AS tags, ST_AsMVTGeom(mvtData.geom, ST_TileEnvelope(?, ?, ?)) AS geom FROM (SELECT id, tags, geom FROM table) AS mvtData WHERE mvtData.geom IS NOT NULL AND mvtData.geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096)) ) AS mvtGeom) AS mvtTile",
         query.sql());
@@ -56,7 +57,7 @@ class PostgresTileStoreTest {
   @Test
   void prepareLegacyQuery() {
     var postgresTileStore = new PostgresTileStore(null, tileset, 15);
-    var query = postgresTileStore.prepareQuery(10);
+    var query = postgresTileStore.prepareQuery(new TileCoord(1, 1, 10));
     assertEquals(
         "SELECT (SELECT ST_AsMVT(mvtGeom.*, 'a') FROM (SELECT mvtData.id AS id, mvtData.tags - 'id' AS tags, ST_AsMVTGeom(mvtData.geom, ST_TileEnvelope(?, ?, ?)) AS geom FROM (SELECT id, tags, geom FROM table WHERE geom IS NOT NULL AND geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096))) as mvtData ) AS mvtGeom) || (SELECT ST_AsMVT(mvtGeom.*, 'b') FROM (SELECT mvtData.id AS id, mvtData.tags - 'id' AS tags, ST_AsMVTGeom(mvtData.geom, ST_TileEnvelope(?, ?, ?)) AS geom FROM (SELECT id, tags, geom FROM table WHERE geom IS NOT NULL AND geom && ST_TileEnvelope(?, ?, ?, margin => (64.0/4096))) as mvtData ) AS mvtGeom) AS mvtTile",
         query.sql());

--- a/baremaps-postgres/src/main/java/org/apache/baremaps/postgres/utils/PostgresUtils.java
+++ b/baremaps-postgres/src/main/java/org/apache/baremaps/postgres/utils/PostgresUtils.java
@@ -178,4 +178,17 @@ public final class PostgresUtils {
       statement.execute(queries);
     }
   }
+
+  /**
+   * Gets the version of the Postgres database.
+   *
+   * @param datasource the data source
+   * @return the version of the Postgres database
+   * @throws SQLException if a database access error occurs
+   */
+  public static int getPostgresVersion(DataSource datasource) throws SQLException {
+    try (Connection connection = datasource.getConnection()) {
+      return connection.getMetaData().getDatabaseMajorVersion();
+    }
+  }
 }


### PR DESCRIPTION
Generate different queries depending on the postgresql version.

Recent versions of postgis will use subqueries as the query optimizer allows it. This allows for more complex user provided queries in the tileset. Legacy versions (<16) append conditions to the user provided queries to allow for better performance.