### PR TITLE
Fix rat:check with pregenerated files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -748,6 +748,8 @@ limitations under the License.
             <exclude>**/.run/</exclude>
             <exclude>**/.github/</exclude>
             <exclude>**/.mvn/</exclude>
+            <exclude>**/target/</exclude>
+            <exclude>**/dependency-reduced-pom.xml</exclude>
 
             <!-- Files with undetected headers -->
             <exclude>**/vector_tile.proto</exclude>


### PR DESCRIPTION
This PR addresses the problem of `mvn apache-rat:check ` which fails if run after an install command because of the generated files.