### PR TITLE
Automatically Add new Label to Newly Created Issues and Close Inactive Issues and PRs After a Certain Period

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -1,0 +1,32 @@
+name: Close inactive issues and PRs
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+permissions: read-all
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9
+        with:
+          only-labels: "status: waiting-for-feedback" # only consider issues and PRs with this label
+          days-before-stale: 30 # 1 month
+          days-before-close: 60 # 2 months after being stale
+          stale-issue-label: "status: stale"
+          stale-pr-label: "status: stale"
+          stale-issue-message: >
+            If you would like us to be able to process this issue, please provide the requested information.
+            If the information is not provided within the next 2 months, we will be unable to proceed and this issue will be closed.
+          close-issue-message: >
+            Closing due to lack of requested feedback.
+            If you would like to proceed with your contribution, please provide the requested information and we will re-open this issue.
+          stale-pr-message: >
+            If you would like us to be able to process this pull request, please provide the requested information or make the requested changes.
+            If the information is not provided or the requested changes are not made within the next 2 months, we will be unable to proceed and this pull request will be closed.
+          close-pr-message: >
+            Closing due to lack of requested feedback.
+            If you would like to proceed with your contribution, please provide the requested information or make the requested changes, and we will re-open this pull request.

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -19,14 +19,14 @@ jobs:
           stale-issue-label: "status: stale"
           stale-pr-label: "status: stale"
           stale-issue-message: >
-            If you would like us to be able to process this issue, please provide the requested information.
-            If the information is not provided within the next 2 months, we will be unable to proceed and this issue will be closed.
+            This issue has been inactive for a while. If you’re still interested, let us know how we can help! Our community is small, and we need contributors like you. 
+            If we don’t hear back, we may close it, but you’re always welcome to reopen it. Let’s build this together! 🚀
           close-issue-message: >
-            Closing due to lack of requested feedback.
-            If you would like to proceed with your contribution, please provide the requested information and we will re-open this issue.
+            Closing this issue due to inactivity. If you’re still interested, let us know! Our community is small, and we need contributors like you. 
+            If you provide more details or take the lead on a solution, we’ll be happy to re-open it. Let’s build this together! 🚀
           stale-pr-message: >
-            If you would like us to be able to process this pull request, please provide the requested information or make the requested changes.
-            If the information is not provided or the requested changes are not made within the next 2 months, we will be unable to proceed and this pull request will be closed.
+            This PR has been inactive for a while. If you’re still working on it, let us know how we can help! Our community is small, and we need contributors like you. 
+            If we don’t hear back, we may close it, but you’re always welcome to reopen it. Let’s build this together! 🚀
           close-pr-message: >
-            Closing due to lack of requested feedback.
-            If you would like to proceed with your contribution, please provide the requested information or make the requested changes, and we will re-open this pull request.
+            Closing this PR due to inactivity. If you’d like to continue, let us know! Our community is small, and we need contributors like you. 
+            Feel free to re-open this PR or submit a new one when you’re ready. Let’s build this together! 🚀

--- a/.github/workflows/label-opened-issues.yml
+++ b/.github/workflows/label-opened-issues.yml
@@ -1,0 +1,30 @@
+name: Add label to opened issues
+on:
+  issues:
+    types:
+      - opened
+permissions: read-all
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const issue = await github.rest.issues.get({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const originalLabels = issue.data.labels.map(l => l.name);
+            const statusLabels = originalLabels.filter(l => l.startsWith("status: "));
+            if (statusLabels.length === 0) {
+              github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ["status: new"]
+              })
+            }


### PR DESCRIPTION
Resolves #926 

## Discussion
Before merging this branch, there are a few things I’d like to discuss.

`issue opened`, `close` actions are based on the `status: xxx` label. For example, in GitHub Actions, when an issue is created, it gets labeled with `status: new.` Then, for issues or PRs labeled with `status: waiting-for-feedback` checks are performed, and if there’s no further action after a certain period, the issue or PR gets closed.

A good example of this is `JUnit5`, which is an open-source project I’m very familiar with. 
They manage issues and PRs using the `status: ` label, and from my experience, it works well.

I’d like to bring this approach to Baremaps!

WDYT?