### PR TITLE
improve Reproducible Builds details

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,7 +41,7 @@ git checkout -b release-$RELEASE_VERSION
 - [ ] Set the release version and commit the changes:
 
 ```bash 
-./mvnw versions:set -DnewVersion=$RELEASE_VERSION
+./mvnw versions:set -DnewVersion=$RELEASE_VERSION -DgenerateBackupPoms=false
 git commit -a -m "Release Baremaps $RELEASE_VERSION"
 git push --set-upstream origin release-$RELEASE_VERSION
 ```
@@ -90,7 +90,7 @@ svn cp https://dist.apache.org/repos/dist/dev/incubator/baremaps/$RELEASE_VERSIO
 - [ ] Set the version of the next iteration and commit the changes:
 
 ```bash
-./mvnw versions:set -DnewVersion=$NEXT_VERSION-SNAPSHOT
+./mvnw versions:set -DnewVersion=$NEXT_VERSION-SNAPSHOT -DgenerateBackupPoms=false
 git commit -a -m "Prepare for next development iteration"
 git push origin
 ```
@@ -116,7 +116,7 @@ docker run \
   -v $(pwd):/baremaps \
   -w /baremaps \
   eclipse-temurin:17-jdk \
-  ./mvnw clean install -DskipTests
+  ./mvnw clean verify -DskipTests artifact:compare -Dreference.repo=https://repository.apache.org/content/repositories/staging/
 ```
 
 ## Verifying the release artifacts

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,6 @@ limitations under the License.
 
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
     <project.build.outputTimestamp>2025-02-26T10:10:41Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -116,15 +114,15 @@ limitations under the License.
     <version.lib.testcontainers>1.20.1</version.lib.testcontainers>
     <version.plugin.jacoco-maven-plugin>0.8.11</version.plugin.jacoco-maven-plugin>
     <version.plugin.jib-maven-plugin>3.0.0</version.plugin.jib-maven-plugin>
-    <version.plugin.maven-compiler-plugin>3.10.1</version.plugin.maven-compiler-plugin>
+    <version.plugin.maven-compiler-plugin>3.14.0</version.plugin.maven-compiler-plugin>
     <version.plugin.maven-exec-plugin>3.0.0</version.plugin.maven-exec-plugin>
     <version.plugin.maven-gpg-plugin>1.6</version.plugin.maven-gpg-plugin>
-    <version.plugin.maven-jar-plugin>3.3.0</version.plugin.maven-jar-plugin>
-    <version.plugin.maven-javadoc-plugin>3.2.0</version.plugin.maven-javadoc-plugin>
+    <version.plugin.maven-jar-plugin>3.4.2</version.plugin.maven-jar-plugin>
+    <version.plugin.maven-javadoc-plugin>3.11.2</version.plugin.maven-javadoc-plugin>
     <version.plugin.maven-jxr-plugin>3.3.1</version.plugin.maven-jxr-plugin>
-    <version.plugin.maven-release-plugin>2.5.3</version.plugin.maven-release-plugin>
+    <version.plugin.maven-release-plugin>3.1.1</version.plugin.maven-release-plugin>
     <version.plugin.maven-scm-plugin>1.11.2</version.plugin.maven-scm-plugin>
-    <version.plugin.maven-source-plugin>3.2.1</version.plugin.maven-source-plugin>
+    <version.plugin.maven-source-plugin>3.3.1</version.plugin.maven-source-plugin>
     <version.plugin.maven-surefire-plugin>3.2.1</version.plugin.maven-surefire-plugin>
     <version.plugin.maven-surefire-plugin.provider.junit>1.3.2</version.plugin.maven-surefire-plugin.provider.junit>
     <version.plugin.nexus-staging-maven-plugin>1.6.13</version.plugin.nexus-staging-maven-plugin>
@@ -700,7 +698,6 @@ limitations under the License.
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${version.plugin.maven-compiler-plugin}</version>
         <configuration>
-          <release>17</release>
           <compilerArgs>
             <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
           </compilerArgs>
@@ -717,14 +714,9 @@ limitations under the License.
         <version>${version.plugin.maven-jar-plugin}</version>
         <configuration>
           <archive>
-            <manifestEntries>
-              <Build-Date>${project.build.outputTimestamp}</Build-Date>
-              <Build-Version>${project.version}</Build-Version>
-              <Build-Jdk>${java.version}</Build-Jdk>
-              <Specification-Title>${project.name}</Specification-Title>
-              <Specification-Vendor>Apache Software Foundation</Specification-Vendor>
-              <Implementation-Vendor>Apache Software Foundation</Implementation-Vendor>
-            </manifestEntries>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
           </archive>
         </configuration>
       </plugin>


### PR DESCRIPTION
result for 0.8.1 was really good https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/baremaps/README.md
it just need limited tweaks to make it easier, avoid backup files in archives https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/baremaps/baremaps-0.8.1.diffoscope
and help voters check their local rebuild against original release candidate

I'm confident, next release will solve the last small issue found in 0.8.1