### PR TITLE
Close the possibility of a RCE in Apache Parquet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ limitations under the License.
     <version.lib.junit>5.11.0</version.lib.junit>
     <version.lib.log4j>3.0.0-beta2</version.lib.log4j>
     <version.lib.lucene>9.11.1</version.lib.lucene>
-    <version.lib.parquet>1.14.2</version.lib.parquet>
+    <version.lib.parquet>1.15.1</version.lib.parquet>
     <version.lib.pgbulkinsert>8.1.4</version.lib.pgbulkinsert>
     <version.lib.picocli>4.7.6</version.lib.picocli>
     <version.lib.postgresql>42.7.4</version.lib.postgresql>


### PR DESCRIPTION
Please see the detail in https://nvd.nist.gov/vuln/detail/CVE-2025-30065 for why this is being opened. It is likely not a serious exposure here in this library, but will help end users avoid blocked releases in the near term.

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.dependencies.UpgradeDependencyVersion?organizationId=QXBhY2hl#defaults%3DW3sibmFtZSI6Imdyb3VwSWQiLCJ2YWx1ZSI6Im9yZy5hcGFjaGUucGFycXVldCoifSx7Im5hbWUiOiJhcnRpZmFjdElkIiwidmFsdWUiOiIqIn0seyJuYW1lIjoibmV3VmVyc2lvbiIsInZhbHVlIjoiMS4xNS54In0seyJuYW1lIjoib3ZlcnJpZGVNYW5hZ2VkVmVyc2lvbiIsInZhbHVlIjoiVHJ1ZSJ9LHsibmFtZSI6InJldGFpblZlcnNpb25zIiwidmFsdWUiOltdfV0%3D