### PR TITLE
Improved test (type) in RpslObjectTest by converting into parameterized unit test

### DIFF
--- a/baremaps-rpsl/src/test/java/org/apache/baremaps/rpsl/RpslObjectTest.java
+++ b/baremaps-rpsl/src/test/java/org/apache/baremaps/rpsl/RpslObjectTest.java
@@ -22,9 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.stream.Stream;
 import org.apache.baremaps.testing.TestFiles;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class RpslObjectTest {
 
@@ -38,11 +42,17 @@ class RpslObjectTest {
     }
   }
 
-  @Test
-  void type() {
-    assertEquals("inetnum", objects.get(0).type());
-    assertEquals("organisation", objects.get(8).type());
-    assertEquals("inet6num", objects.get(9).type());
+  @ParameterizedTest
+  @MethodSource("typeProvider")
+  void testType(int index, String expectedType) {
+    assertEquals(expectedType, objects.get(index).type());
+  }
+
+  private static Stream<Arguments> typeProvider() {
+    return Stream.of(
+        Arguments.of(0, "inetnum"),
+        Arguments.of(8, "organisation"),
+        Arguments.of(9, "inet6num"));
   }
 
   @Test


### PR DESCRIPTION
**Summary**: 
- Parameterized tests : `type` and changed name to `testType`

**Elaboration**: 
- The same method call (`objects.get(x).type()`) is repeated multiple times with different inputs, making it redundant and the test harder to maintain and extend. 
- When a test fails, JUnit only shows which assertion failed, but not which specific input caused the failure.
- Adding new test cases requires copying and pasting another line of assertion statement instead of simply adding new data.

To accomplish this, I retrofitted this tests into a parameterized unit test. This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.
Also, when run each value set is shown its separate pass/fail status. 